### PR TITLE
Refactor Layout and update pages

### DIFF
--- a/src/__generated__/gatsby-types.d.ts
+++ b/src/__generated__/gatsby-types.d.ts
@@ -6799,6 +6799,73 @@ enum ContentfulFoodTypeTagFieldsEnum {
   recipe___yield = 'recipe.yield',
   recipe___prepTime = 'recipe.prepTime',
   recipe___totalTime = 'recipe.totalTime',
+  recipe___featured = 'recipe.featured',
+  recipe___mainImage___contentful_id = 'recipe.mainImage.contentful_id',
+  recipe___mainImage___id = 'recipe.mainImage.id',
+  recipe___mainImage___spaceId = 'recipe.mainImage.spaceId',
+  recipe___mainImage___createdAt = 'recipe.mainImage.createdAt',
+  recipe___mainImage___updatedAt = 'recipe.mainImage.updatedAt',
+  recipe___mainImage___file___url = 'recipe.mainImage.file.url',
+  recipe___mainImage___file___fileName = 'recipe.mainImage.file.fileName',
+  recipe___mainImage___file___contentType = 'recipe.mainImage.file.contentType',
+  recipe___mainImage___title = 'recipe.mainImage.title',
+  recipe___mainImage___description = 'recipe.mainImage.description',
+  recipe___mainImage___node_locale = 'recipe.mainImage.node_locale',
+  recipe___mainImage___sys___type = 'recipe.mainImage.sys.type',
+  recipe___mainImage___sys___revision = 'recipe.mainImage.sys.revision',
+  recipe___mainImage___fixed___base64 = 'recipe.mainImage.fixed.base64',
+  recipe___mainImage___fixed___tracedSVG = 'recipe.mainImage.fixed.tracedSVG',
+  recipe___mainImage___fixed___aspectRatio = 'recipe.mainImage.fixed.aspectRatio',
+  recipe___mainImage___fixed___width = 'recipe.mainImage.fixed.width',
+  recipe___mainImage___fixed___height = 'recipe.mainImage.fixed.height',
+  recipe___mainImage___fixed___src = 'recipe.mainImage.fixed.src',
+  recipe___mainImage___fixed___srcSet = 'recipe.mainImage.fixed.srcSet',
+  recipe___mainImage___fixed___srcWebp = 'recipe.mainImage.fixed.srcWebp',
+  recipe___mainImage___fixed___srcSetWebp = 'recipe.mainImage.fixed.srcSetWebp',
+  recipe___mainImage___resolutions___base64 = 'recipe.mainImage.resolutions.base64',
+  recipe___mainImage___resolutions___tracedSVG = 'recipe.mainImage.resolutions.tracedSVG',
+  recipe___mainImage___resolutions___aspectRatio = 'recipe.mainImage.resolutions.aspectRatio',
+  recipe___mainImage___resolutions___width = 'recipe.mainImage.resolutions.width',
+  recipe___mainImage___resolutions___height = 'recipe.mainImage.resolutions.height',
+  recipe___mainImage___resolutions___src = 'recipe.mainImage.resolutions.src',
+  recipe___mainImage___resolutions___srcSet = 'recipe.mainImage.resolutions.srcSet',
+  recipe___mainImage___resolutions___srcWebp = 'recipe.mainImage.resolutions.srcWebp',
+  recipe___mainImage___resolutions___srcSetWebp = 'recipe.mainImage.resolutions.srcSetWebp',
+  recipe___mainImage___fluid___base64 = 'recipe.mainImage.fluid.base64',
+  recipe___mainImage___fluid___tracedSVG = 'recipe.mainImage.fluid.tracedSVG',
+  recipe___mainImage___fluid___aspectRatio = 'recipe.mainImage.fluid.aspectRatio',
+  recipe___mainImage___fluid___src = 'recipe.mainImage.fluid.src',
+  recipe___mainImage___fluid___srcSet = 'recipe.mainImage.fluid.srcSet',
+  recipe___mainImage___fluid___srcWebp = 'recipe.mainImage.fluid.srcWebp',
+  recipe___mainImage___fluid___srcSetWebp = 'recipe.mainImage.fluid.srcSetWebp',
+  recipe___mainImage___fluid___sizes = 'recipe.mainImage.fluid.sizes',
+  recipe___mainImage___sizes___base64 = 'recipe.mainImage.sizes.base64',
+  recipe___mainImage___sizes___tracedSVG = 'recipe.mainImage.sizes.tracedSVG',
+  recipe___mainImage___sizes___aspectRatio = 'recipe.mainImage.sizes.aspectRatio',
+  recipe___mainImage___sizes___src = 'recipe.mainImage.sizes.src',
+  recipe___mainImage___sizes___srcSet = 'recipe.mainImage.sizes.srcSet',
+  recipe___mainImage___sizes___srcWebp = 'recipe.mainImage.sizes.srcWebp',
+  recipe___mainImage___sizes___srcSetWebp = 'recipe.mainImage.sizes.srcSetWebp',
+  recipe___mainImage___sizes___sizes = 'recipe.mainImage.sizes.sizes',
+  recipe___mainImage___resize___base64 = 'recipe.mainImage.resize.base64',
+  recipe___mainImage___resize___tracedSVG = 'recipe.mainImage.resize.tracedSVG',
+  recipe___mainImage___resize___src = 'recipe.mainImage.resize.src',
+  recipe___mainImage___resize___width = 'recipe.mainImage.resize.width',
+  recipe___mainImage___resize___height = 'recipe.mainImage.resize.height',
+  recipe___mainImage___resize___aspectRatio = 'recipe.mainImage.resize.aspectRatio',
+  recipe___mainImage___parent___id = 'recipe.mainImage.parent.id',
+  recipe___mainImage___parent___children = 'recipe.mainImage.parent.children',
+  recipe___mainImage___children = 'recipe.mainImage.children',
+  recipe___mainImage___children___id = 'recipe.mainImage.children.id',
+  recipe___mainImage___children___children = 'recipe.mainImage.children.children',
+  recipe___mainImage___internal___content = 'recipe.mainImage.internal.content',
+  recipe___mainImage___internal___contentDigest = 'recipe.mainImage.internal.contentDigest',
+  recipe___mainImage___internal___description = 'recipe.mainImage.internal.description',
+  recipe___mainImage___internal___fieldOwners = 'recipe.mainImage.internal.fieldOwners',
+  recipe___mainImage___internal___ignoreType = 'recipe.mainImage.internal.ignoreType',
+  recipe___mainImage___internal___mediaType = 'recipe.mainImage.internal.mediaType',
+  recipe___mainImage___internal___owner = 'recipe.mainImage.internal.owner',
+  recipe___mainImage___internal___type = 'recipe.mainImage.internal.type',
   recipe___description___id = 'recipe.description.id',
   recipe___description___parent___id = 'recipe.description.parent.id',
   recipe___description___parent___children = 'recipe.description.parent.children',
@@ -6989,7 +7056,6 @@ enum ContentfulFoodTypeTagFieldsEnum {
   recipe___updatedAt = 'recipe.updatedAt',
   recipe___sys___type = 'recipe.sys.type',
   recipe___sys___revision = 'recipe.sys.revision',
-  recipe___featured = 'recipe.featured',
   recipe___ingredientTags = 'recipe.ingredientTags',
   recipe___ingredientTags___contentful_id = 'recipe.ingredientTags.contentful_id',
   recipe___ingredientTags___id = 'recipe.ingredientTags.id',
@@ -7004,10 +7070,10 @@ enum ContentfulFoodTypeTagFieldsEnum {
   recipe___ingredientTags___recipe___yield = 'recipe.ingredientTags.recipe.yield',
   recipe___ingredientTags___recipe___prepTime = 'recipe.ingredientTags.recipe.prepTime',
   recipe___ingredientTags___recipe___totalTime = 'recipe.ingredientTags.recipe.totalTime',
+  recipe___ingredientTags___recipe___featured = 'recipe.ingredientTags.recipe.featured',
   recipe___ingredientTags___recipe___spaceId = 'recipe.ingredientTags.recipe.spaceId',
   recipe___ingredientTags___recipe___createdAt = 'recipe.ingredientTags.recipe.createdAt',
   recipe___ingredientTags___recipe___updatedAt = 'recipe.ingredientTags.recipe.updatedAt',
-  recipe___ingredientTags___recipe___featured = 'recipe.ingredientTags.recipe.featured',
   recipe___ingredientTags___recipe___ingredientTags = 'recipe.ingredientTags.recipe.ingredientTags',
   recipe___ingredientTags___recipe___foodTypeTags = 'recipe.ingredientTags.recipe.foodTypeTags',
   recipe___ingredientTags___recipe___gatsbyPath = 'recipe.ingredientTags.recipe.gatsbyPath',
@@ -7049,10 +7115,10 @@ enum ContentfulFoodTypeTagFieldsEnum {
   recipe___foodTypeTags___recipe___yield = 'recipe.foodTypeTags.recipe.yield',
   recipe___foodTypeTags___recipe___prepTime = 'recipe.foodTypeTags.recipe.prepTime',
   recipe___foodTypeTags___recipe___totalTime = 'recipe.foodTypeTags.recipe.totalTime',
+  recipe___foodTypeTags___recipe___featured = 'recipe.foodTypeTags.recipe.featured',
   recipe___foodTypeTags___recipe___spaceId = 'recipe.foodTypeTags.recipe.spaceId',
   recipe___foodTypeTags___recipe___createdAt = 'recipe.foodTypeTags.recipe.createdAt',
   recipe___foodTypeTags___recipe___updatedAt = 'recipe.foodTypeTags.recipe.updatedAt',
-  recipe___foodTypeTags___recipe___featured = 'recipe.foodTypeTags.recipe.featured',
   recipe___foodTypeTags___recipe___ingredientTags = 'recipe.foodTypeTags.recipe.ingredientTags',
   recipe___foodTypeTags___recipe___foodTypeTags = 'recipe.foodTypeTags.recipe.foodTypeTags',
   recipe___foodTypeTags___recipe___gatsbyPath = 'recipe.foodTypeTags.recipe.gatsbyPath',
@@ -7080,72 +7146,6 @@ enum ContentfulFoodTypeTagFieldsEnum {
   recipe___foodTypeTags___internal___mediaType = 'recipe.foodTypeTags.internal.mediaType',
   recipe___foodTypeTags___internal___owner = 'recipe.foodTypeTags.internal.owner',
   recipe___foodTypeTags___internal___type = 'recipe.foodTypeTags.internal.type',
-  recipe___mainImage___contentful_id = 'recipe.mainImage.contentful_id',
-  recipe___mainImage___id = 'recipe.mainImage.id',
-  recipe___mainImage___spaceId = 'recipe.mainImage.spaceId',
-  recipe___mainImage___createdAt = 'recipe.mainImage.createdAt',
-  recipe___mainImage___updatedAt = 'recipe.mainImage.updatedAt',
-  recipe___mainImage___file___url = 'recipe.mainImage.file.url',
-  recipe___mainImage___file___fileName = 'recipe.mainImage.file.fileName',
-  recipe___mainImage___file___contentType = 'recipe.mainImage.file.contentType',
-  recipe___mainImage___title = 'recipe.mainImage.title',
-  recipe___mainImage___description = 'recipe.mainImage.description',
-  recipe___mainImage___node_locale = 'recipe.mainImage.node_locale',
-  recipe___mainImage___sys___type = 'recipe.mainImage.sys.type',
-  recipe___mainImage___sys___revision = 'recipe.mainImage.sys.revision',
-  recipe___mainImage___fixed___base64 = 'recipe.mainImage.fixed.base64',
-  recipe___mainImage___fixed___tracedSVG = 'recipe.mainImage.fixed.tracedSVG',
-  recipe___mainImage___fixed___aspectRatio = 'recipe.mainImage.fixed.aspectRatio',
-  recipe___mainImage___fixed___width = 'recipe.mainImage.fixed.width',
-  recipe___mainImage___fixed___height = 'recipe.mainImage.fixed.height',
-  recipe___mainImage___fixed___src = 'recipe.mainImage.fixed.src',
-  recipe___mainImage___fixed___srcSet = 'recipe.mainImage.fixed.srcSet',
-  recipe___mainImage___fixed___srcWebp = 'recipe.mainImage.fixed.srcWebp',
-  recipe___mainImage___fixed___srcSetWebp = 'recipe.mainImage.fixed.srcSetWebp',
-  recipe___mainImage___resolutions___base64 = 'recipe.mainImage.resolutions.base64',
-  recipe___mainImage___resolutions___tracedSVG = 'recipe.mainImage.resolutions.tracedSVG',
-  recipe___mainImage___resolutions___aspectRatio = 'recipe.mainImage.resolutions.aspectRatio',
-  recipe___mainImage___resolutions___width = 'recipe.mainImage.resolutions.width',
-  recipe___mainImage___resolutions___height = 'recipe.mainImage.resolutions.height',
-  recipe___mainImage___resolutions___src = 'recipe.mainImage.resolutions.src',
-  recipe___mainImage___resolutions___srcSet = 'recipe.mainImage.resolutions.srcSet',
-  recipe___mainImage___resolutions___srcWebp = 'recipe.mainImage.resolutions.srcWebp',
-  recipe___mainImage___resolutions___srcSetWebp = 'recipe.mainImage.resolutions.srcSetWebp',
-  recipe___mainImage___fluid___base64 = 'recipe.mainImage.fluid.base64',
-  recipe___mainImage___fluid___tracedSVG = 'recipe.mainImage.fluid.tracedSVG',
-  recipe___mainImage___fluid___aspectRatio = 'recipe.mainImage.fluid.aspectRatio',
-  recipe___mainImage___fluid___src = 'recipe.mainImage.fluid.src',
-  recipe___mainImage___fluid___srcSet = 'recipe.mainImage.fluid.srcSet',
-  recipe___mainImage___fluid___srcWebp = 'recipe.mainImage.fluid.srcWebp',
-  recipe___mainImage___fluid___srcSetWebp = 'recipe.mainImage.fluid.srcSetWebp',
-  recipe___mainImage___fluid___sizes = 'recipe.mainImage.fluid.sizes',
-  recipe___mainImage___sizes___base64 = 'recipe.mainImage.sizes.base64',
-  recipe___mainImage___sizes___tracedSVG = 'recipe.mainImage.sizes.tracedSVG',
-  recipe___mainImage___sizes___aspectRatio = 'recipe.mainImage.sizes.aspectRatio',
-  recipe___mainImage___sizes___src = 'recipe.mainImage.sizes.src',
-  recipe___mainImage___sizes___srcSet = 'recipe.mainImage.sizes.srcSet',
-  recipe___mainImage___sizes___srcWebp = 'recipe.mainImage.sizes.srcWebp',
-  recipe___mainImage___sizes___srcSetWebp = 'recipe.mainImage.sizes.srcSetWebp',
-  recipe___mainImage___sizes___sizes = 'recipe.mainImage.sizes.sizes',
-  recipe___mainImage___resize___base64 = 'recipe.mainImage.resize.base64',
-  recipe___mainImage___resize___tracedSVG = 'recipe.mainImage.resize.tracedSVG',
-  recipe___mainImage___resize___src = 'recipe.mainImage.resize.src',
-  recipe___mainImage___resize___width = 'recipe.mainImage.resize.width',
-  recipe___mainImage___resize___height = 'recipe.mainImage.resize.height',
-  recipe___mainImage___resize___aspectRatio = 'recipe.mainImage.resize.aspectRatio',
-  recipe___mainImage___parent___id = 'recipe.mainImage.parent.id',
-  recipe___mainImage___parent___children = 'recipe.mainImage.parent.children',
-  recipe___mainImage___children = 'recipe.mainImage.children',
-  recipe___mainImage___children___id = 'recipe.mainImage.children.id',
-  recipe___mainImage___children___children = 'recipe.mainImage.children.children',
-  recipe___mainImage___internal___content = 'recipe.mainImage.internal.content',
-  recipe___mainImage___internal___contentDigest = 'recipe.mainImage.internal.contentDigest',
-  recipe___mainImage___internal___description = 'recipe.mainImage.internal.description',
-  recipe___mainImage___internal___fieldOwners = 'recipe.mainImage.internal.fieldOwners',
-  recipe___mainImage___internal___ignoreType = 'recipe.mainImage.internal.ignoreType',
-  recipe___mainImage___internal___mediaType = 'recipe.mainImage.internal.mediaType',
-  recipe___mainImage___internal___owner = 'recipe.mainImage.internal.owner',
-  recipe___mainImage___internal___type = 'recipe.mainImage.internal.type',
   recipe___gatsbyPath = 'recipe.gatsbyPath',
   recipe___childrenContentfulRecipeNotesTextNode = 'recipe.childrenContentfulRecipeNotesTextNode',
   recipe___childrenContentfulRecipeNotesTextNode___id = 'recipe.childrenContentfulRecipeNotesTextNode.id',
@@ -7726,6 +7726,7 @@ type ContentfulGetInvolvedCard = ContentfulReference & ContentfulEntry & Node & 
   readonly node_locale: Scalars['String'];
   readonly title: Maybe<Scalars['String']>;
   readonly link: Maybe<Scalars['String']>;
+  readonly description: Maybe<Scalars['String']>;
   readonly icon: Maybe<ContentfulAsset>;
   readonly spaceId: Maybe<Scalars['String']>;
   readonly createdAt: Maybe<Scalars['Date']>;
@@ -7785,6 +7786,7 @@ enum ContentfulGetInvolvedCardFieldsEnum {
   node_locale = 'node_locale',
   title = 'title',
   link = 'link',
+  description = 'description',
   icon___contentful_id = 'icon.contentful_id',
   icon___id = 'icon.id',
   icon___spaceId = 'icon.spaceId',
@@ -7977,6 +7979,7 @@ type ContentfulGetInvolvedCardFilterInput = {
   readonly node_locale: Maybe<StringQueryOperatorInput>;
   readonly title: Maybe<StringQueryOperatorInput>;
   readonly link: Maybe<StringQueryOperatorInput>;
+  readonly description: Maybe<StringQueryOperatorInput>;
   readonly icon: Maybe<ContentfulAssetFilterInput>;
   readonly spaceId: Maybe<StringQueryOperatorInput>;
   readonly createdAt: Maybe<DateQueryOperatorInput>;
@@ -8354,6 +8357,7 @@ type ContentfulHomeBanner = ContentfulReference & ContentfulEntry & Node & {
   readonly titleLine2: Maybe<Scalars['String']>;
   readonly ctaLink: Maybe<Scalars['String']>;
   readonly ctaText: Maybe<Scalars['String']>;
+  readonly image: Maybe<ContentfulAsset>;
   readonly body: Maybe<contentfulHomeBannerBodyTextNode>;
   readonly spaceId: Maybe<Scalars['String']>;
   readonly createdAt: Maybe<Scalars['Date']>;
@@ -8697,6 +8701,97 @@ enum ContentfulHomeBannerFieldsEnum {
   titleLine2 = 'titleLine2',
   ctaLink = 'ctaLink',
   ctaText = 'ctaText',
+  image___contentful_id = 'image.contentful_id',
+  image___id = 'image.id',
+  image___spaceId = 'image.spaceId',
+  image___createdAt = 'image.createdAt',
+  image___updatedAt = 'image.updatedAt',
+  image___file___url = 'image.file.url',
+  image___file___details___size = 'image.file.details.size',
+  image___file___fileName = 'image.file.fileName',
+  image___file___contentType = 'image.file.contentType',
+  image___title = 'image.title',
+  image___description = 'image.description',
+  image___node_locale = 'image.node_locale',
+  image___sys___type = 'image.sys.type',
+  image___sys___revision = 'image.sys.revision',
+  image___fixed___base64 = 'image.fixed.base64',
+  image___fixed___tracedSVG = 'image.fixed.tracedSVG',
+  image___fixed___aspectRatio = 'image.fixed.aspectRatio',
+  image___fixed___width = 'image.fixed.width',
+  image___fixed___height = 'image.fixed.height',
+  image___fixed___src = 'image.fixed.src',
+  image___fixed___srcSet = 'image.fixed.srcSet',
+  image___fixed___srcWebp = 'image.fixed.srcWebp',
+  image___fixed___srcSetWebp = 'image.fixed.srcSetWebp',
+  image___resolutions___base64 = 'image.resolutions.base64',
+  image___resolutions___tracedSVG = 'image.resolutions.tracedSVG',
+  image___resolutions___aspectRatio = 'image.resolutions.aspectRatio',
+  image___resolutions___width = 'image.resolutions.width',
+  image___resolutions___height = 'image.resolutions.height',
+  image___resolutions___src = 'image.resolutions.src',
+  image___resolutions___srcSet = 'image.resolutions.srcSet',
+  image___resolutions___srcWebp = 'image.resolutions.srcWebp',
+  image___resolutions___srcSetWebp = 'image.resolutions.srcSetWebp',
+  image___fluid___base64 = 'image.fluid.base64',
+  image___fluid___tracedSVG = 'image.fluid.tracedSVG',
+  image___fluid___aspectRatio = 'image.fluid.aspectRatio',
+  image___fluid___src = 'image.fluid.src',
+  image___fluid___srcSet = 'image.fluid.srcSet',
+  image___fluid___srcWebp = 'image.fluid.srcWebp',
+  image___fluid___srcSetWebp = 'image.fluid.srcSetWebp',
+  image___fluid___sizes = 'image.fluid.sizes',
+  image___sizes___base64 = 'image.sizes.base64',
+  image___sizes___tracedSVG = 'image.sizes.tracedSVG',
+  image___sizes___aspectRatio = 'image.sizes.aspectRatio',
+  image___sizes___src = 'image.sizes.src',
+  image___sizes___srcSet = 'image.sizes.srcSet',
+  image___sizes___srcWebp = 'image.sizes.srcWebp',
+  image___sizes___srcSetWebp = 'image.sizes.srcSetWebp',
+  image___sizes___sizes = 'image.sizes.sizes',
+  image___resize___base64 = 'image.resize.base64',
+  image___resize___tracedSVG = 'image.resize.tracedSVG',
+  image___resize___src = 'image.resize.src',
+  image___resize___width = 'image.resize.width',
+  image___resize___height = 'image.resize.height',
+  image___resize___aspectRatio = 'image.resize.aspectRatio',
+  image___parent___id = 'image.parent.id',
+  image___parent___parent___id = 'image.parent.parent.id',
+  image___parent___parent___children = 'image.parent.parent.children',
+  image___parent___children = 'image.parent.children',
+  image___parent___children___id = 'image.parent.children.id',
+  image___parent___children___children = 'image.parent.children.children',
+  image___parent___internal___content = 'image.parent.internal.content',
+  image___parent___internal___contentDigest = 'image.parent.internal.contentDigest',
+  image___parent___internal___description = 'image.parent.internal.description',
+  image___parent___internal___fieldOwners = 'image.parent.internal.fieldOwners',
+  image___parent___internal___ignoreType = 'image.parent.internal.ignoreType',
+  image___parent___internal___mediaType = 'image.parent.internal.mediaType',
+  image___parent___internal___owner = 'image.parent.internal.owner',
+  image___parent___internal___type = 'image.parent.internal.type',
+  image___children = 'image.children',
+  image___children___id = 'image.children.id',
+  image___children___parent___id = 'image.children.parent.id',
+  image___children___parent___children = 'image.children.parent.children',
+  image___children___children = 'image.children.children',
+  image___children___children___id = 'image.children.children.id',
+  image___children___children___children = 'image.children.children.children',
+  image___children___internal___content = 'image.children.internal.content',
+  image___children___internal___contentDigest = 'image.children.internal.contentDigest',
+  image___children___internal___description = 'image.children.internal.description',
+  image___children___internal___fieldOwners = 'image.children.internal.fieldOwners',
+  image___children___internal___ignoreType = 'image.children.internal.ignoreType',
+  image___children___internal___mediaType = 'image.children.internal.mediaType',
+  image___children___internal___owner = 'image.children.internal.owner',
+  image___children___internal___type = 'image.children.internal.type',
+  image___internal___content = 'image.internal.content',
+  image___internal___contentDigest = 'image.internal.contentDigest',
+  image___internal___description = 'image.internal.description',
+  image___internal___fieldOwners = 'image.internal.fieldOwners',
+  image___internal___ignoreType = 'image.internal.ignoreType',
+  image___internal___mediaType = 'image.internal.mediaType',
+  image___internal___owner = 'image.internal.owner',
+  image___internal___type = 'image.internal.type',
   body___id = 'body.id',
   body___parent___id = 'body.parent.id',
   body___parent___parent___id = 'body.parent.parent.id',
@@ -9098,6 +9193,7 @@ type ContentfulHomeBannerFilterInput = {
   readonly titleLine2: Maybe<StringQueryOperatorInput>;
   readonly ctaLink: Maybe<StringQueryOperatorInput>;
   readonly ctaText: Maybe<StringQueryOperatorInput>;
+  readonly image: Maybe<ContentfulAssetFilterInput>;
   readonly body: Maybe<contentfulHomeBannerBodyTextNodeFilterInput>;
   readonly spaceId: Maybe<StringQueryOperatorInput>;
   readonly createdAt: Maybe<DateQueryOperatorInput>;
@@ -10057,6 +10153,73 @@ enum ContentfulIngredientTagFieldsEnum {
   recipe___yield = 'recipe.yield',
   recipe___prepTime = 'recipe.prepTime',
   recipe___totalTime = 'recipe.totalTime',
+  recipe___featured = 'recipe.featured',
+  recipe___mainImage___contentful_id = 'recipe.mainImage.contentful_id',
+  recipe___mainImage___id = 'recipe.mainImage.id',
+  recipe___mainImage___spaceId = 'recipe.mainImage.spaceId',
+  recipe___mainImage___createdAt = 'recipe.mainImage.createdAt',
+  recipe___mainImage___updatedAt = 'recipe.mainImage.updatedAt',
+  recipe___mainImage___file___url = 'recipe.mainImage.file.url',
+  recipe___mainImage___file___fileName = 'recipe.mainImage.file.fileName',
+  recipe___mainImage___file___contentType = 'recipe.mainImage.file.contentType',
+  recipe___mainImage___title = 'recipe.mainImage.title',
+  recipe___mainImage___description = 'recipe.mainImage.description',
+  recipe___mainImage___node_locale = 'recipe.mainImage.node_locale',
+  recipe___mainImage___sys___type = 'recipe.mainImage.sys.type',
+  recipe___mainImage___sys___revision = 'recipe.mainImage.sys.revision',
+  recipe___mainImage___fixed___base64 = 'recipe.mainImage.fixed.base64',
+  recipe___mainImage___fixed___tracedSVG = 'recipe.mainImage.fixed.tracedSVG',
+  recipe___mainImage___fixed___aspectRatio = 'recipe.mainImage.fixed.aspectRatio',
+  recipe___mainImage___fixed___width = 'recipe.mainImage.fixed.width',
+  recipe___mainImage___fixed___height = 'recipe.mainImage.fixed.height',
+  recipe___mainImage___fixed___src = 'recipe.mainImage.fixed.src',
+  recipe___mainImage___fixed___srcSet = 'recipe.mainImage.fixed.srcSet',
+  recipe___mainImage___fixed___srcWebp = 'recipe.mainImage.fixed.srcWebp',
+  recipe___mainImage___fixed___srcSetWebp = 'recipe.mainImage.fixed.srcSetWebp',
+  recipe___mainImage___resolutions___base64 = 'recipe.mainImage.resolutions.base64',
+  recipe___mainImage___resolutions___tracedSVG = 'recipe.mainImage.resolutions.tracedSVG',
+  recipe___mainImage___resolutions___aspectRatio = 'recipe.mainImage.resolutions.aspectRatio',
+  recipe___mainImage___resolutions___width = 'recipe.mainImage.resolutions.width',
+  recipe___mainImage___resolutions___height = 'recipe.mainImage.resolutions.height',
+  recipe___mainImage___resolutions___src = 'recipe.mainImage.resolutions.src',
+  recipe___mainImage___resolutions___srcSet = 'recipe.mainImage.resolutions.srcSet',
+  recipe___mainImage___resolutions___srcWebp = 'recipe.mainImage.resolutions.srcWebp',
+  recipe___mainImage___resolutions___srcSetWebp = 'recipe.mainImage.resolutions.srcSetWebp',
+  recipe___mainImage___fluid___base64 = 'recipe.mainImage.fluid.base64',
+  recipe___mainImage___fluid___tracedSVG = 'recipe.mainImage.fluid.tracedSVG',
+  recipe___mainImage___fluid___aspectRatio = 'recipe.mainImage.fluid.aspectRatio',
+  recipe___mainImage___fluid___src = 'recipe.mainImage.fluid.src',
+  recipe___mainImage___fluid___srcSet = 'recipe.mainImage.fluid.srcSet',
+  recipe___mainImage___fluid___srcWebp = 'recipe.mainImage.fluid.srcWebp',
+  recipe___mainImage___fluid___srcSetWebp = 'recipe.mainImage.fluid.srcSetWebp',
+  recipe___mainImage___fluid___sizes = 'recipe.mainImage.fluid.sizes',
+  recipe___mainImage___sizes___base64 = 'recipe.mainImage.sizes.base64',
+  recipe___mainImage___sizes___tracedSVG = 'recipe.mainImage.sizes.tracedSVG',
+  recipe___mainImage___sizes___aspectRatio = 'recipe.mainImage.sizes.aspectRatio',
+  recipe___mainImage___sizes___src = 'recipe.mainImage.sizes.src',
+  recipe___mainImage___sizes___srcSet = 'recipe.mainImage.sizes.srcSet',
+  recipe___mainImage___sizes___srcWebp = 'recipe.mainImage.sizes.srcWebp',
+  recipe___mainImage___sizes___srcSetWebp = 'recipe.mainImage.sizes.srcSetWebp',
+  recipe___mainImage___sizes___sizes = 'recipe.mainImage.sizes.sizes',
+  recipe___mainImage___resize___base64 = 'recipe.mainImage.resize.base64',
+  recipe___mainImage___resize___tracedSVG = 'recipe.mainImage.resize.tracedSVG',
+  recipe___mainImage___resize___src = 'recipe.mainImage.resize.src',
+  recipe___mainImage___resize___width = 'recipe.mainImage.resize.width',
+  recipe___mainImage___resize___height = 'recipe.mainImage.resize.height',
+  recipe___mainImage___resize___aspectRatio = 'recipe.mainImage.resize.aspectRatio',
+  recipe___mainImage___parent___id = 'recipe.mainImage.parent.id',
+  recipe___mainImage___parent___children = 'recipe.mainImage.parent.children',
+  recipe___mainImage___children = 'recipe.mainImage.children',
+  recipe___mainImage___children___id = 'recipe.mainImage.children.id',
+  recipe___mainImage___children___children = 'recipe.mainImage.children.children',
+  recipe___mainImage___internal___content = 'recipe.mainImage.internal.content',
+  recipe___mainImage___internal___contentDigest = 'recipe.mainImage.internal.contentDigest',
+  recipe___mainImage___internal___description = 'recipe.mainImage.internal.description',
+  recipe___mainImage___internal___fieldOwners = 'recipe.mainImage.internal.fieldOwners',
+  recipe___mainImage___internal___ignoreType = 'recipe.mainImage.internal.ignoreType',
+  recipe___mainImage___internal___mediaType = 'recipe.mainImage.internal.mediaType',
+  recipe___mainImage___internal___owner = 'recipe.mainImage.internal.owner',
+  recipe___mainImage___internal___type = 'recipe.mainImage.internal.type',
   recipe___description___id = 'recipe.description.id',
   recipe___description___parent___id = 'recipe.description.parent.id',
   recipe___description___parent___children = 'recipe.description.parent.children',
@@ -10247,7 +10410,6 @@ enum ContentfulIngredientTagFieldsEnum {
   recipe___updatedAt = 'recipe.updatedAt',
   recipe___sys___type = 'recipe.sys.type',
   recipe___sys___revision = 'recipe.sys.revision',
-  recipe___featured = 'recipe.featured',
   recipe___ingredientTags = 'recipe.ingredientTags',
   recipe___ingredientTags___contentful_id = 'recipe.ingredientTags.contentful_id',
   recipe___ingredientTags___id = 'recipe.ingredientTags.id',
@@ -10262,10 +10424,10 @@ enum ContentfulIngredientTagFieldsEnum {
   recipe___ingredientTags___recipe___yield = 'recipe.ingredientTags.recipe.yield',
   recipe___ingredientTags___recipe___prepTime = 'recipe.ingredientTags.recipe.prepTime',
   recipe___ingredientTags___recipe___totalTime = 'recipe.ingredientTags.recipe.totalTime',
+  recipe___ingredientTags___recipe___featured = 'recipe.ingredientTags.recipe.featured',
   recipe___ingredientTags___recipe___spaceId = 'recipe.ingredientTags.recipe.spaceId',
   recipe___ingredientTags___recipe___createdAt = 'recipe.ingredientTags.recipe.createdAt',
   recipe___ingredientTags___recipe___updatedAt = 'recipe.ingredientTags.recipe.updatedAt',
-  recipe___ingredientTags___recipe___featured = 'recipe.ingredientTags.recipe.featured',
   recipe___ingredientTags___recipe___ingredientTags = 'recipe.ingredientTags.recipe.ingredientTags',
   recipe___ingredientTags___recipe___foodTypeTags = 'recipe.ingredientTags.recipe.foodTypeTags',
   recipe___ingredientTags___recipe___gatsbyPath = 'recipe.ingredientTags.recipe.gatsbyPath',
@@ -10307,10 +10469,10 @@ enum ContentfulIngredientTagFieldsEnum {
   recipe___foodTypeTags___recipe___yield = 'recipe.foodTypeTags.recipe.yield',
   recipe___foodTypeTags___recipe___prepTime = 'recipe.foodTypeTags.recipe.prepTime',
   recipe___foodTypeTags___recipe___totalTime = 'recipe.foodTypeTags.recipe.totalTime',
+  recipe___foodTypeTags___recipe___featured = 'recipe.foodTypeTags.recipe.featured',
   recipe___foodTypeTags___recipe___spaceId = 'recipe.foodTypeTags.recipe.spaceId',
   recipe___foodTypeTags___recipe___createdAt = 'recipe.foodTypeTags.recipe.createdAt',
   recipe___foodTypeTags___recipe___updatedAt = 'recipe.foodTypeTags.recipe.updatedAt',
-  recipe___foodTypeTags___recipe___featured = 'recipe.foodTypeTags.recipe.featured',
   recipe___foodTypeTags___recipe___ingredientTags = 'recipe.foodTypeTags.recipe.ingredientTags',
   recipe___foodTypeTags___recipe___foodTypeTags = 'recipe.foodTypeTags.recipe.foodTypeTags',
   recipe___foodTypeTags___recipe___gatsbyPath = 'recipe.foodTypeTags.recipe.gatsbyPath',
@@ -10338,72 +10500,6 @@ enum ContentfulIngredientTagFieldsEnum {
   recipe___foodTypeTags___internal___mediaType = 'recipe.foodTypeTags.internal.mediaType',
   recipe___foodTypeTags___internal___owner = 'recipe.foodTypeTags.internal.owner',
   recipe___foodTypeTags___internal___type = 'recipe.foodTypeTags.internal.type',
-  recipe___mainImage___contentful_id = 'recipe.mainImage.contentful_id',
-  recipe___mainImage___id = 'recipe.mainImage.id',
-  recipe___mainImage___spaceId = 'recipe.mainImage.spaceId',
-  recipe___mainImage___createdAt = 'recipe.mainImage.createdAt',
-  recipe___mainImage___updatedAt = 'recipe.mainImage.updatedAt',
-  recipe___mainImage___file___url = 'recipe.mainImage.file.url',
-  recipe___mainImage___file___fileName = 'recipe.mainImage.file.fileName',
-  recipe___mainImage___file___contentType = 'recipe.mainImage.file.contentType',
-  recipe___mainImage___title = 'recipe.mainImage.title',
-  recipe___mainImage___description = 'recipe.mainImage.description',
-  recipe___mainImage___node_locale = 'recipe.mainImage.node_locale',
-  recipe___mainImage___sys___type = 'recipe.mainImage.sys.type',
-  recipe___mainImage___sys___revision = 'recipe.mainImage.sys.revision',
-  recipe___mainImage___fixed___base64 = 'recipe.mainImage.fixed.base64',
-  recipe___mainImage___fixed___tracedSVG = 'recipe.mainImage.fixed.tracedSVG',
-  recipe___mainImage___fixed___aspectRatio = 'recipe.mainImage.fixed.aspectRatio',
-  recipe___mainImage___fixed___width = 'recipe.mainImage.fixed.width',
-  recipe___mainImage___fixed___height = 'recipe.mainImage.fixed.height',
-  recipe___mainImage___fixed___src = 'recipe.mainImage.fixed.src',
-  recipe___mainImage___fixed___srcSet = 'recipe.mainImage.fixed.srcSet',
-  recipe___mainImage___fixed___srcWebp = 'recipe.mainImage.fixed.srcWebp',
-  recipe___mainImage___fixed___srcSetWebp = 'recipe.mainImage.fixed.srcSetWebp',
-  recipe___mainImage___resolutions___base64 = 'recipe.mainImage.resolutions.base64',
-  recipe___mainImage___resolutions___tracedSVG = 'recipe.mainImage.resolutions.tracedSVG',
-  recipe___mainImage___resolutions___aspectRatio = 'recipe.mainImage.resolutions.aspectRatio',
-  recipe___mainImage___resolutions___width = 'recipe.mainImage.resolutions.width',
-  recipe___mainImage___resolutions___height = 'recipe.mainImage.resolutions.height',
-  recipe___mainImage___resolutions___src = 'recipe.mainImage.resolutions.src',
-  recipe___mainImage___resolutions___srcSet = 'recipe.mainImage.resolutions.srcSet',
-  recipe___mainImage___resolutions___srcWebp = 'recipe.mainImage.resolutions.srcWebp',
-  recipe___mainImage___resolutions___srcSetWebp = 'recipe.mainImage.resolutions.srcSetWebp',
-  recipe___mainImage___fluid___base64 = 'recipe.mainImage.fluid.base64',
-  recipe___mainImage___fluid___tracedSVG = 'recipe.mainImage.fluid.tracedSVG',
-  recipe___mainImage___fluid___aspectRatio = 'recipe.mainImage.fluid.aspectRatio',
-  recipe___mainImage___fluid___src = 'recipe.mainImage.fluid.src',
-  recipe___mainImage___fluid___srcSet = 'recipe.mainImage.fluid.srcSet',
-  recipe___mainImage___fluid___srcWebp = 'recipe.mainImage.fluid.srcWebp',
-  recipe___mainImage___fluid___srcSetWebp = 'recipe.mainImage.fluid.srcSetWebp',
-  recipe___mainImage___fluid___sizes = 'recipe.mainImage.fluid.sizes',
-  recipe___mainImage___sizes___base64 = 'recipe.mainImage.sizes.base64',
-  recipe___mainImage___sizes___tracedSVG = 'recipe.mainImage.sizes.tracedSVG',
-  recipe___mainImage___sizes___aspectRatio = 'recipe.mainImage.sizes.aspectRatio',
-  recipe___mainImage___sizes___src = 'recipe.mainImage.sizes.src',
-  recipe___mainImage___sizes___srcSet = 'recipe.mainImage.sizes.srcSet',
-  recipe___mainImage___sizes___srcWebp = 'recipe.mainImage.sizes.srcWebp',
-  recipe___mainImage___sizes___srcSetWebp = 'recipe.mainImage.sizes.srcSetWebp',
-  recipe___mainImage___sizes___sizes = 'recipe.mainImage.sizes.sizes',
-  recipe___mainImage___resize___base64 = 'recipe.mainImage.resize.base64',
-  recipe___mainImage___resize___tracedSVG = 'recipe.mainImage.resize.tracedSVG',
-  recipe___mainImage___resize___src = 'recipe.mainImage.resize.src',
-  recipe___mainImage___resize___width = 'recipe.mainImage.resize.width',
-  recipe___mainImage___resize___height = 'recipe.mainImage.resize.height',
-  recipe___mainImage___resize___aspectRatio = 'recipe.mainImage.resize.aspectRatio',
-  recipe___mainImage___parent___id = 'recipe.mainImage.parent.id',
-  recipe___mainImage___parent___children = 'recipe.mainImage.parent.children',
-  recipe___mainImage___children = 'recipe.mainImage.children',
-  recipe___mainImage___children___id = 'recipe.mainImage.children.id',
-  recipe___mainImage___children___children = 'recipe.mainImage.children.children',
-  recipe___mainImage___internal___content = 'recipe.mainImage.internal.content',
-  recipe___mainImage___internal___contentDigest = 'recipe.mainImage.internal.contentDigest',
-  recipe___mainImage___internal___description = 'recipe.mainImage.internal.description',
-  recipe___mainImage___internal___fieldOwners = 'recipe.mainImage.internal.fieldOwners',
-  recipe___mainImage___internal___ignoreType = 'recipe.mainImage.internal.ignoreType',
-  recipe___mainImage___internal___mediaType = 'recipe.mainImage.internal.mediaType',
-  recipe___mainImage___internal___owner = 'recipe.mainImage.internal.owner',
-  recipe___mainImage___internal___type = 'recipe.mainImage.internal.type',
   recipe___gatsbyPath = 'recipe.gatsbyPath',
   recipe___childrenContentfulRecipeNotesTextNode = 'recipe.childrenContentfulRecipeNotesTextNode',
   recipe___childrenContentfulRecipeNotesTextNode___id = 'recipe.childrenContentfulRecipeNotesTextNode.id',
@@ -16865,6 +16961,8 @@ type ContentfulRecipe = ContentfulReference & ContentfulEntry & Node & {
   readonly yield: Maybe<Scalars['String']>;
   readonly prepTime: Maybe<Scalars['Int']>;
   readonly totalTime: Maybe<Scalars['Int']>;
+  readonly featured: Maybe<Scalars['Boolean']>;
+  readonly mainImage: Maybe<ContentfulAsset>;
   readonly description: Maybe<contentfulRecipeDescriptionTextNode>;
   readonly ingredients: Maybe<contentfulRecipeIngredientsTextNode>;
   readonly prepDirections: Maybe<contentfulRecipePrepDirectionsTextNode>;
@@ -16874,10 +16972,8 @@ type ContentfulRecipe = ContentfulReference & ContentfulEntry & Node & {
   readonly createdAt: Maybe<Scalars['Date']>;
   readonly updatedAt: Maybe<Scalars['Date']>;
   readonly sys: Maybe<ContentfulRecipeSys>;
-  readonly featured: Maybe<Scalars['Boolean']>;
   readonly ingredientTags: Maybe<ReadonlyArray<Maybe<ContentfulIngredientTag>>>;
   readonly foodTypeTags: Maybe<ReadonlyArray<Maybe<ContentfulFoodTypeTag>>>;
-  readonly mainImage: Maybe<ContentfulAsset>;
   readonly gatsbyPath: Maybe<Scalars['String']>;
   /** Returns all children nodes filtered by type contentfulRecipeNotesTextNode */
   readonly childrenContentfulRecipeNotesTextNode: Maybe<ReadonlyArray<Maybe<contentfulRecipeNotesTextNode>>>;
@@ -17525,6 +17621,98 @@ enum ContentfulRecipeFieldsEnum {
   yield = 'yield',
   prepTime = 'prepTime',
   totalTime = 'totalTime',
+  featured = 'featured',
+  mainImage___contentful_id = 'mainImage.contentful_id',
+  mainImage___id = 'mainImage.id',
+  mainImage___spaceId = 'mainImage.spaceId',
+  mainImage___createdAt = 'mainImage.createdAt',
+  mainImage___updatedAt = 'mainImage.updatedAt',
+  mainImage___file___url = 'mainImage.file.url',
+  mainImage___file___details___size = 'mainImage.file.details.size',
+  mainImage___file___fileName = 'mainImage.file.fileName',
+  mainImage___file___contentType = 'mainImage.file.contentType',
+  mainImage___title = 'mainImage.title',
+  mainImage___description = 'mainImage.description',
+  mainImage___node_locale = 'mainImage.node_locale',
+  mainImage___sys___type = 'mainImage.sys.type',
+  mainImage___sys___revision = 'mainImage.sys.revision',
+  mainImage___fixed___base64 = 'mainImage.fixed.base64',
+  mainImage___fixed___tracedSVG = 'mainImage.fixed.tracedSVG',
+  mainImage___fixed___aspectRatio = 'mainImage.fixed.aspectRatio',
+  mainImage___fixed___width = 'mainImage.fixed.width',
+  mainImage___fixed___height = 'mainImage.fixed.height',
+  mainImage___fixed___src = 'mainImage.fixed.src',
+  mainImage___fixed___srcSet = 'mainImage.fixed.srcSet',
+  mainImage___fixed___srcWebp = 'mainImage.fixed.srcWebp',
+  mainImage___fixed___srcSetWebp = 'mainImage.fixed.srcSetWebp',
+  mainImage___resolutions___base64 = 'mainImage.resolutions.base64',
+  mainImage___resolutions___tracedSVG = 'mainImage.resolutions.tracedSVG',
+  mainImage___resolutions___aspectRatio = 'mainImage.resolutions.aspectRatio',
+  mainImage___resolutions___width = 'mainImage.resolutions.width',
+  mainImage___resolutions___height = 'mainImage.resolutions.height',
+  mainImage___resolutions___src = 'mainImage.resolutions.src',
+  mainImage___resolutions___srcSet = 'mainImage.resolutions.srcSet',
+  mainImage___resolutions___srcWebp = 'mainImage.resolutions.srcWebp',
+  mainImage___resolutions___srcSetWebp = 'mainImage.resolutions.srcSetWebp',
+  mainImage___fluid___base64 = 'mainImage.fluid.base64',
+  mainImage___fluid___tracedSVG = 'mainImage.fluid.tracedSVG',
+  mainImage___fluid___aspectRatio = 'mainImage.fluid.aspectRatio',
+  mainImage___fluid___src = 'mainImage.fluid.src',
+  mainImage___fluid___srcSet = 'mainImage.fluid.srcSet',
+  mainImage___fluid___srcWebp = 'mainImage.fluid.srcWebp',
+  mainImage___fluid___srcSetWebp = 'mainImage.fluid.srcSetWebp',
+  mainImage___fluid___sizes = 'mainImage.fluid.sizes',
+  mainImage___sizes___base64 = 'mainImage.sizes.base64',
+  mainImage___sizes___tracedSVG = 'mainImage.sizes.tracedSVG',
+  mainImage___sizes___aspectRatio = 'mainImage.sizes.aspectRatio',
+  mainImage___sizes___src = 'mainImage.sizes.src',
+  mainImage___sizes___srcSet = 'mainImage.sizes.srcSet',
+  mainImage___sizes___srcWebp = 'mainImage.sizes.srcWebp',
+  mainImage___sizes___srcSetWebp = 'mainImage.sizes.srcSetWebp',
+  mainImage___sizes___sizes = 'mainImage.sizes.sizes',
+  mainImage___resize___base64 = 'mainImage.resize.base64',
+  mainImage___resize___tracedSVG = 'mainImage.resize.tracedSVG',
+  mainImage___resize___src = 'mainImage.resize.src',
+  mainImage___resize___width = 'mainImage.resize.width',
+  mainImage___resize___height = 'mainImage.resize.height',
+  mainImage___resize___aspectRatio = 'mainImage.resize.aspectRatio',
+  mainImage___parent___id = 'mainImage.parent.id',
+  mainImage___parent___parent___id = 'mainImage.parent.parent.id',
+  mainImage___parent___parent___children = 'mainImage.parent.parent.children',
+  mainImage___parent___children = 'mainImage.parent.children',
+  mainImage___parent___children___id = 'mainImage.parent.children.id',
+  mainImage___parent___children___children = 'mainImage.parent.children.children',
+  mainImage___parent___internal___content = 'mainImage.parent.internal.content',
+  mainImage___parent___internal___contentDigest = 'mainImage.parent.internal.contentDigest',
+  mainImage___parent___internal___description = 'mainImage.parent.internal.description',
+  mainImage___parent___internal___fieldOwners = 'mainImage.parent.internal.fieldOwners',
+  mainImage___parent___internal___ignoreType = 'mainImage.parent.internal.ignoreType',
+  mainImage___parent___internal___mediaType = 'mainImage.parent.internal.mediaType',
+  mainImage___parent___internal___owner = 'mainImage.parent.internal.owner',
+  mainImage___parent___internal___type = 'mainImage.parent.internal.type',
+  mainImage___children = 'mainImage.children',
+  mainImage___children___id = 'mainImage.children.id',
+  mainImage___children___parent___id = 'mainImage.children.parent.id',
+  mainImage___children___parent___children = 'mainImage.children.parent.children',
+  mainImage___children___children = 'mainImage.children.children',
+  mainImage___children___children___id = 'mainImage.children.children.id',
+  mainImage___children___children___children = 'mainImage.children.children.children',
+  mainImage___children___internal___content = 'mainImage.children.internal.content',
+  mainImage___children___internal___contentDigest = 'mainImage.children.internal.contentDigest',
+  mainImage___children___internal___description = 'mainImage.children.internal.description',
+  mainImage___children___internal___fieldOwners = 'mainImage.children.internal.fieldOwners',
+  mainImage___children___internal___ignoreType = 'mainImage.children.internal.ignoreType',
+  mainImage___children___internal___mediaType = 'mainImage.children.internal.mediaType',
+  mainImage___children___internal___owner = 'mainImage.children.internal.owner',
+  mainImage___children___internal___type = 'mainImage.children.internal.type',
+  mainImage___internal___content = 'mainImage.internal.content',
+  mainImage___internal___contentDigest = 'mainImage.internal.contentDigest',
+  mainImage___internal___description = 'mainImage.internal.description',
+  mainImage___internal___fieldOwners = 'mainImage.internal.fieldOwners',
+  mainImage___internal___ignoreType = 'mainImage.internal.ignoreType',
+  mainImage___internal___mediaType = 'mainImage.internal.mediaType',
+  mainImage___internal___owner = 'mainImage.internal.owner',
+  mainImage___internal___type = 'mainImage.internal.type',
   description___id = 'description.id',
   description___parent___id = 'description.parent.id',
   description___parent___parent___id = 'description.parent.parent.id',
@@ -18028,7 +18216,6 @@ enum ContentfulRecipeFieldsEnum {
   sys___contentType___sys___type = 'sys.contentType.sys.type',
   sys___contentType___sys___linkType = 'sys.contentType.sys.linkType',
   sys___contentType___sys___id = 'sys.contentType.sys.id',
-  featured = 'featured',
   ingredientTags = 'ingredientTags',
   ingredientTags___contentful_id = 'ingredientTags.contentful_id',
   ingredientTags___id = 'ingredientTags.id',
@@ -18043,6 +18230,16 @@ enum ContentfulRecipeFieldsEnum {
   ingredientTags___recipe___yield = 'ingredientTags.recipe.yield',
   ingredientTags___recipe___prepTime = 'ingredientTags.recipe.prepTime',
   ingredientTags___recipe___totalTime = 'ingredientTags.recipe.totalTime',
+  ingredientTags___recipe___featured = 'ingredientTags.recipe.featured',
+  ingredientTags___recipe___mainImage___contentful_id = 'ingredientTags.recipe.mainImage.contentful_id',
+  ingredientTags___recipe___mainImage___id = 'ingredientTags.recipe.mainImage.id',
+  ingredientTags___recipe___mainImage___spaceId = 'ingredientTags.recipe.mainImage.spaceId',
+  ingredientTags___recipe___mainImage___createdAt = 'ingredientTags.recipe.mainImage.createdAt',
+  ingredientTags___recipe___mainImage___updatedAt = 'ingredientTags.recipe.mainImage.updatedAt',
+  ingredientTags___recipe___mainImage___title = 'ingredientTags.recipe.mainImage.title',
+  ingredientTags___recipe___mainImage___description = 'ingredientTags.recipe.mainImage.description',
+  ingredientTags___recipe___mainImage___node_locale = 'ingredientTags.recipe.mainImage.node_locale',
+  ingredientTags___recipe___mainImage___children = 'ingredientTags.recipe.mainImage.children',
   ingredientTags___recipe___description___id = 'ingredientTags.recipe.description.id',
   ingredientTags___recipe___description___children = 'ingredientTags.recipe.description.children',
   ingredientTags___recipe___description___description = 'ingredientTags.recipe.description.description',
@@ -18068,7 +18265,6 @@ enum ContentfulRecipeFieldsEnum {
   ingredientTags___recipe___updatedAt = 'ingredientTags.recipe.updatedAt',
   ingredientTags___recipe___sys___type = 'ingredientTags.recipe.sys.type',
   ingredientTags___recipe___sys___revision = 'ingredientTags.recipe.sys.revision',
-  ingredientTags___recipe___featured = 'ingredientTags.recipe.featured',
   ingredientTags___recipe___ingredientTags = 'ingredientTags.recipe.ingredientTags',
   ingredientTags___recipe___ingredientTags___contentful_id = 'ingredientTags.recipe.ingredientTags.contentful_id',
   ingredientTags___recipe___ingredientTags___id = 'ingredientTags.recipe.ingredientTags.id',
@@ -18091,15 +18287,6 @@ enum ContentfulRecipeFieldsEnum {
   ingredientTags___recipe___foodTypeTags___createdAt = 'ingredientTags.recipe.foodTypeTags.createdAt',
   ingredientTags___recipe___foodTypeTags___updatedAt = 'ingredientTags.recipe.foodTypeTags.updatedAt',
   ingredientTags___recipe___foodTypeTags___children = 'ingredientTags.recipe.foodTypeTags.children',
-  ingredientTags___recipe___mainImage___contentful_id = 'ingredientTags.recipe.mainImage.contentful_id',
-  ingredientTags___recipe___mainImage___id = 'ingredientTags.recipe.mainImage.id',
-  ingredientTags___recipe___mainImage___spaceId = 'ingredientTags.recipe.mainImage.spaceId',
-  ingredientTags___recipe___mainImage___createdAt = 'ingredientTags.recipe.mainImage.createdAt',
-  ingredientTags___recipe___mainImage___updatedAt = 'ingredientTags.recipe.mainImage.updatedAt',
-  ingredientTags___recipe___mainImage___title = 'ingredientTags.recipe.mainImage.title',
-  ingredientTags___recipe___mainImage___description = 'ingredientTags.recipe.mainImage.description',
-  ingredientTags___recipe___mainImage___node_locale = 'ingredientTags.recipe.mainImage.node_locale',
-  ingredientTags___recipe___mainImage___children = 'ingredientTags.recipe.mainImage.children',
   ingredientTags___recipe___gatsbyPath = 'ingredientTags.recipe.gatsbyPath',
   ingredientTags___recipe___childrenContentfulRecipeNotesTextNode = 'ingredientTags.recipe.childrenContentfulRecipeNotesTextNode',
   ingredientTags___recipe___childrenContentfulRecipeNotesTextNode___id = 'ingredientTags.recipe.childrenContentfulRecipeNotesTextNode.id',
@@ -18215,6 +18402,16 @@ enum ContentfulRecipeFieldsEnum {
   foodTypeTags___recipe___yield = 'foodTypeTags.recipe.yield',
   foodTypeTags___recipe___prepTime = 'foodTypeTags.recipe.prepTime',
   foodTypeTags___recipe___totalTime = 'foodTypeTags.recipe.totalTime',
+  foodTypeTags___recipe___featured = 'foodTypeTags.recipe.featured',
+  foodTypeTags___recipe___mainImage___contentful_id = 'foodTypeTags.recipe.mainImage.contentful_id',
+  foodTypeTags___recipe___mainImage___id = 'foodTypeTags.recipe.mainImage.id',
+  foodTypeTags___recipe___mainImage___spaceId = 'foodTypeTags.recipe.mainImage.spaceId',
+  foodTypeTags___recipe___mainImage___createdAt = 'foodTypeTags.recipe.mainImage.createdAt',
+  foodTypeTags___recipe___mainImage___updatedAt = 'foodTypeTags.recipe.mainImage.updatedAt',
+  foodTypeTags___recipe___mainImage___title = 'foodTypeTags.recipe.mainImage.title',
+  foodTypeTags___recipe___mainImage___description = 'foodTypeTags.recipe.mainImage.description',
+  foodTypeTags___recipe___mainImage___node_locale = 'foodTypeTags.recipe.mainImage.node_locale',
+  foodTypeTags___recipe___mainImage___children = 'foodTypeTags.recipe.mainImage.children',
   foodTypeTags___recipe___description___id = 'foodTypeTags.recipe.description.id',
   foodTypeTags___recipe___description___children = 'foodTypeTags.recipe.description.children',
   foodTypeTags___recipe___description___description = 'foodTypeTags.recipe.description.description',
@@ -18240,7 +18437,6 @@ enum ContentfulRecipeFieldsEnum {
   foodTypeTags___recipe___updatedAt = 'foodTypeTags.recipe.updatedAt',
   foodTypeTags___recipe___sys___type = 'foodTypeTags.recipe.sys.type',
   foodTypeTags___recipe___sys___revision = 'foodTypeTags.recipe.sys.revision',
-  foodTypeTags___recipe___featured = 'foodTypeTags.recipe.featured',
   foodTypeTags___recipe___ingredientTags = 'foodTypeTags.recipe.ingredientTags',
   foodTypeTags___recipe___ingredientTags___contentful_id = 'foodTypeTags.recipe.ingredientTags.contentful_id',
   foodTypeTags___recipe___ingredientTags___id = 'foodTypeTags.recipe.ingredientTags.id',
@@ -18263,15 +18459,6 @@ enum ContentfulRecipeFieldsEnum {
   foodTypeTags___recipe___foodTypeTags___createdAt = 'foodTypeTags.recipe.foodTypeTags.createdAt',
   foodTypeTags___recipe___foodTypeTags___updatedAt = 'foodTypeTags.recipe.foodTypeTags.updatedAt',
   foodTypeTags___recipe___foodTypeTags___children = 'foodTypeTags.recipe.foodTypeTags.children',
-  foodTypeTags___recipe___mainImage___contentful_id = 'foodTypeTags.recipe.mainImage.contentful_id',
-  foodTypeTags___recipe___mainImage___id = 'foodTypeTags.recipe.mainImage.id',
-  foodTypeTags___recipe___mainImage___spaceId = 'foodTypeTags.recipe.mainImage.spaceId',
-  foodTypeTags___recipe___mainImage___createdAt = 'foodTypeTags.recipe.mainImage.createdAt',
-  foodTypeTags___recipe___mainImage___updatedAt = 'foodTypeTags.recipe.mainImage.updatedAt',
-  foodTypeTags___recipe___mainImage___title = 'foodTypeTags.recipe.mainImage.title',
-  foodTypeTags___recipe___mainImage___description = 'foodTypeTags.recipe.mainImage.description',
-  foodTypeTags___recipe___mainImage___node_locale = 'foodTypeTags.recipe.mainImage.node_locale',
-  foodTypeTags___recipe___mainImage___children = 'foodTypeTags.recipe.mainImage.children',
   foodTypeTags___recipe___gatsbyPath = 'foodTypeTags.recipe.gatsbyPath',
   foodTypeTags___recipe___childrenContentfulRecipeNotesTextNode = 'foodTypeTags.recipe.childrenContentfulRecipeNotesTextNode',
   foodTypeTags___recipe___childrenContentfulRecipeNotesTextNode___id = 'foodTypeTags.recipe.childrenContentfulRecipeNotesTextNode.id',
@@ -18373,97 +18560,6 @@ enum ContentfulRecipeFieldsEnum {
   foodTypeTags___internal___mediaType = 'foodTypeTags.internal.mediaType',
   foodTypeTags___internal___owner = 'foodTypeTags.internal.owner',
   foodTypeTags___internal___type = 'foodTypeTags.internal.type',
-  mainImage___contentful_id = 'mainImage.contentful_id',
-  mainImage___id = 'mainImage.id',
-  mainImage___spaceId = 'mainImage.spaceId',
-  mainImage___createdAt = 'mainImage.createdAt',
-  mainImage___updatedAt = 'mainImage.updatedAt',
-  mainImage___file___url = 'mainImage.file.url',
-  mainImage___file___details___size = 'mainImage.file.details.size',
-  mainImage___file___fileName = 'mainImage.file.fileName',
-  mainImage___file___contentType = 'mainImage.file.contentType',
-  mainImage___title = 'mainImage.title',
-  mainImage___description = 'mainImage.description',
-  mainImage___node_locale = 'mainImage.node_locale',
-  mainImage___sys___type = 'mainImage.sys.type',
-  mainImage___sys___revision = 'mainImage.sys.revision',
-  mainImage___fixed___base64 = 'mainImage.fixed.base64',
-  mainImage___fixed___tracedSVG = 'mainImage.fixed.tracedSVG',
-  mainImage___fixed___aspectRatio = 'mainImage.fixed.aspectRatio',
-  mainImage___fixed___width = 'mainImage.fixed.width',
-  mainImage___fixed___height = 'mainImage.fixed.height',
-  mainImage___fixed___src = 'mainImage.fixed.src',
-  mainImage___fixed___srcSet = 'mainImage.fixed.srcSet',
-  mainImage___fixed___srcWebp = 'mainImage.fixed.srcWebp',
-  mainImage___fixed___srcSetWebp = 'mainImage.fixed.srcSetWebp',
-  mainImage___resolutions___base64 = 'mainImage.resolutions.base64',
-  mainImage___resolutions___tracedSVG = 'mainImage.resolutions.tracedSVG',
-  mainImage___resolutions___aspectRatio = 'mainImage.resolutions.aspectRatio',
-  mainImage___resolutions___width = 'mainImage.resolutions.width',
-  mainImage___resolutions___height = 'mainImage.resolutions.height',
-  mainImage___resolutions___src = 'mainImage.resolutions.src',
-  mainImage___resolutions___srcSet = 'mainImage.resolutions.srcSet',
-  mainImage___resolutions___srcWebp = 'mainImage.resolutions.srcWebp',
-  mainImage___resolutions___srcSetWebp = 'mainImage.resolutions.srcSetWebp',
-  mainImage___fluid___base64 = 'mainImage.fluid.base64',
-  mainImage___fluid___tracedSVG = 'mainImage.fluid.tracedSVG',
-  mainImage___fluid___aspectRatio = 'mainImage.fluid.aspectRatio',
-  mainImage___fluid___src = 'mainImage.fluid.src',
-  mainImage___fluid___srcSet = 'mainImage.fluid.srcSet',
-  mainImage___fluid___srcWebp = 'mainImage.fluid.srcWebp',
-  mainImage___fluid___srcSetWebp = 'mainImage.fluid.srcSetWebp',
-  mainImage___fluid___sizes = 'mainImage.fluid.sizes',
-  mainImage___sizes___base64 = 'mainImage.sizes.base64',
-  mainImage___sizes___tracedSVG = 'mainImage.sizes.tracedSVG',
-  mainImage___sizes___aspectRatio = 'mainImage.sizes.aspectRatio',
-  mainImage___sizes___src = 'mainImage.sizes.src',
-  mainImage___sizes___srcSet = 'mainImage.sizes.srcSet',
-  mainImage___sizes___srcWebp = 'mainImage.sizes.srcWebp',
-  mainImage___sizes___srcSetWebp = 'mainImage.sizes.srcSetWebp',
-  mainImage___sizes___sizes = 'mainImage.sizes.sizes',
-  mainImage___resize___base64 = 'mainImage.resize.base64',
-  mainImage___resize___tracedSVG = 'mainImage.resize.tracedSVG',
-  mainImage___resize___src = 'mainImage.resize.src',
-  mainImage___resize___width = 'mainImage.resize.width',
-  mainImage___resize___height = 'mainImage.resize.height',
-  mainImage___resize___aspectRatio = 'mainImage.resize.aspectRatio',
-  mainImage___parent___id = 'mainImage.parent.id',
-  mainImage___parent___parent___id = 'mainImage.parent.parent.id',
-  mainImage___parent___parent___children = 'mainImage.parent.parent.children',
-  mainImage___parent___children = 'mainImage.parent.children',
-  mainImage___parent___children___id = 'mainImage.parent.children.id',
-  mainImage___parent___children___children = 'mainImage.parent.children.children',
-  mainImage___parent___internal___content = 'mainImage.parent.internal.content',
-  mainImage___parent___internal___contentDigest = 'mainImage.parent.internal.contentDigest',
-  mainImage___parent___internal___description = 'mainImage.parent.internal.description',
-  mainImage___parent___internal___fieldOwners = 'mainImage.parent.internal.fieldOwners',
-  mainImage___parent___internal___ignoreType = 'mainImage.parent.internal.ignoreType',
-  mainImage___parent___internal___mediaType = 'mainImage.parent.internal.mediaType',
-  mainImage___parent___internal___owner = 'mainImage.parent.internal.owner',
-  mainImage___parent___internal___type = 'mainImage.parent.internal.type',
-  mainImage___children = 'mainImage.children',
-  mainImage___children___id = 'mainImage.children.id',
-  mainImage___children___parent___id = 'mainImage.children.parent.id',
-  mainImage___children___parent___children = 'mainImage.children.parent.children',
-  mainImage___children___children = 'mainImage.children.children',
-  mainImage___children___children___id = 'mainImage.children.children.id',
-  mainImage___children___children___children = 'mainImage.children.children.children',
-  mainImage___children___internal___content = 'mainImage.children.internal.content',
-  mainImage___children___internal___contentDigest = 'mainImage.children.internal.contentDigest',
-  mainImage___children___internal___description = 'mainImage.children.internal.description',
-  mainImage___children___internal___fieldOwners = 'mainImage.children.internal.fieldOwners',
-  mainImage___children___internal___ignoreType = 'mainImage.children.internal.ignoreType',
-  mainImage___children___internal___mediaType = 'mainImage.children.internal.mediaType',
-  mainImage___children___internal___owner = 'mainImage.children.internal.owner',
-  mainImage___children___internal___type = 'mainImage.children.internal.type',
-  mainImage___internal___content = 'mainImage.internal.content',
-  mainImage___internal___contentDigest = 'mainImage.internal.contentDigest',
-  mainImage___internal___description = 'mainImage.internal.description',
-  mainImage___internal___fieldOwners = 'mainImage.internal.fieldOwners',
-  mainImage___internal___ignoreType = 'mainImage.internal.ignoreType',
-  mainImage___internal___mediaType = 'mainImage.internal.mediaType',
-  mainImage___internal___owner = 'mainImage.internal.owner',
-  mainImage___internal___type = 'mainImage.internal.type',
   gatsbyPath = 'gatsbyPath',
   childrenContentfulRecipeNotesTextNode = 'childrenContentfulRecipeNotesTextNode',
   childrenContentfulRecipeNotesTextNode___id = 'childrenContentfulRecipeNotesTextNode.id',
@@ -19555,6 +19651,8 @@ type ContentfulRecipeFilterInput = {
   readonly yield: Maybe<StringQueryOperatorInput>;
   readonly prepTime: Maybe<IntQueryOperatorInput>;
   readonly totalTime: Maybe<IntQueryOperatorInput>;
+  readonly featured: Maybe<BooleanQueryOperatorInput>;
+  readonly mainImage: Maybe<ContentfulAssetFilterInput>;
   readonly description: Maybe<contentfulRecipeDescriptionTextNodeFilterInput>;
   readonly ingredients: Maybe<contentfulRecipeIngredientsTextNodeFilterInput>;
   readonly prepDirections: Maybe<contentfulRecipePrepDirectionsTextNodeFilterInput>;
@@ -19564,10 +19662,8 @@ type ContentfulRecipeFilterInput = {
   readonly createdAt: Maybe<DateQueryOperatorInput>;
   readonly updatedAt: Maybe<DateQueryOperatorInput>;
   readonly sys: Maybe<ContentfulRecipeSysFilterInput>;
-  readonly featured: Maybe<BooleanQueryOperatorInput>;
   readonly ingredientTags: Maybe<ContentfulIngredientTagFilterListInput>;
   readonly foodTypeTags: Maybe<ContentfulFoodTypeTagFilterListInput>;
-  readonly mainImage: Maybe<ContentfulAssetFilterInput>;
   readonly gatsbyPath: Maybe<StringQueryOperatorInput>;
   readonly childrenContentfulRecipeNotesTextNode: Maybe<contentfulRecipeNotesTextNodeFilterListInput>;
   readonly childContentfulRecipeNotesTextNode: Maybe<contentfulRecipeNotesTextNodeFilterInput>;
@@ -24080,24 +24176,14 @@ type Query = {
   readonly allContentfulErrorPage: ContentfulErrorPageConnection;
   readonly contentfulHeaderSection: Maybe<ContentfulHeaderSection>;
   readonly allContentfulHeaderSection: ContentfulHeaderSectionConnection;
-  readonly contentfulRecipeNotesTextNode: Maybe<contentfulRecipeNotesTextNode>;
-  readonly allContentfulRecipeNotesTextNode: contentfulRecipeNotesTextNodeConnection;
-  readonly contentfulRecipeDirectionsTextNode: Maybe<contentfulRecipeDirectionsTextNode>;
-  readonly allContentfulRecipeDirectionsTextNode: contentfulRecipeDirectionsTextNodeConnection;
-  readonly contentfulRecipePrepDirectionsTextNode: Maybe<contentfulRecipePrepDirectionsTextNode>;
-  readonly allContentfulRecipePrepDirectionsTextNode: contentfulRecipePrepDirectionsTextNodeConnection;
-  readonly contentfulRecipeIngredientsTextNode: Maybe<contentfulRecipeIngredientsTextNode>;
-  readonly allContentfulRecipeIngredientsTextNode: contentfulRecipeIngredientsTextNodeConnection;
-  readonly contentfulRecipeDescriptionTextNode: Maybe<contentfulRecipeDescriptionTextNode>;
-  readonly allContentfulRecipeDescriptionTextNode: contentfulRecipeDescriptionTextNodeConnection;
+  readonly contentfulHomeBannerBodyTextNode: Maybe<contentfulHomeBannerBodyTextNode>;
+  readonly allContentfulHomeBannerBodyTextNode: contentfulHomeBannerBodyTextNodeConnection;
   readonly contentfulResourceCardBodyTextNode: Maybe<contentfulResourceCardBodyTextNode>;
   readonly allContentfulResourceCardBodyTextNode: contentfulResourceCardBodyTextNodeConnection;
   readonly contentfulLinkDocSectionBodyTextNode: Maybe<contentfulLinkDocSectionBodyTextNode>;
   readonly allContentfulLinkDocSectionBodyTextNode: contentfulLinkDocSectionBodyTextNodeConnection;
   readonly contentfulDonationDetailSectionDescriptionTextNode: Maybe<contentfulDonationDetailSectionDescriptionTextNode>;
   readonly allContentfulDonationDetailSectionDescriptionTextNode: contentfulDonationDetailSectionDescriptionTextNodeConnection;
-  readonly contentfulHomeBannerBodyTextNode: Maybe<contentfulHomeBannerBodyTextNode>;
-  readonly allContentfulHomeBannerBodyTextNode: contentfulHomeBannerBodyTextNodeConnection;
   readonly contentfulDonateSectionBodyTextNode: Maybe<contentfulDonateSectionBodyTextNode>;
   readonly allContentfulDonateSectionBodyTextNode: contentfulDonateSectionBodyTextNodeConnection;
   readonly contentfulAboutBannerBodyTextNode: Maybe<contentfulAboutBannerBodyTextNode>;
@@ -24112,6 +24198,16 @@ type Query = {
   readonly allContentfulOurWorkCardDescriptionTextNode: contentfulOurWorkCardDescriptionTextNodeConnection;
   readonly contentfulAboutUsBannerDescriptionTextNode: Maybe<contentfulAboutUsBannerDescriptionTextNode>;
   readonly allContentfulAboutUsBannerDescriptionTextNode: contentfulAboutUsBannerDescriptionTextNodeConnection;
+  readonly contentfulRecipeNotesTextNode: Maybe<contentfulRecipeNotesTextNode>;
+  readonly allContentfulRecipeNotesTextNode: contentfulRecipeNotesTextNodeConnection;
+  readonly contentfulRecipeDirectionsTextNode: Maybe<contentfulRecipeDirectionsTextNode>;
+  readonly allContentfulRecipeDirectionsTextNode: contentfulRecipeDirectionsTextNodeConnection;
+  readonly contentfulRecipePrepDirectionsTextNode: Maybe<contentfulRecipePrepDirectionsTextNode>;
+  readonly allContentfulRecipePrepDirectionsTextNode: contentfulRecipePrepDirectionsTextNodeConnection;
+  readonly contentfulRecipeIngredientsTextNode: Maybe<contentfulRecipeIngredientsTextNode>;
+  readonly allContentfulRecipeIngredientsTextNode: contentfulRecipeIngredientsTextNodeConnection;
+  readonly contentfulRecipeDescriptionTextNode: Maybe<contentfulRecipeDescriptionTextNode>;
+  readonly allContentfulRecipeDescriptionTextNode: contentfulRecipeDescriptionTextNodeConnection;
   readonly contentfulBlogPostBodyTextNode: Maybe<contentfulBlogPostBodyTextNode>;
   readonly allContentfulBlogPostBodyTextNode: contentfulBlogPostBodyTextNodeConnection;
   readonly contentfulBlogPostDescriptionTextNode: Maybe<contentfulBlogPostDescriptionTextNode>;
@@ -24441,6 +24537,8 @@ type Query_contentfulRecipeArgs = {
   yield: Maybe<StringQueryOperatorInput>;
   prepTime: Maybe<IntQueryOperatorInput>;
   totalTime: Maybe<IntQueryOperatorInput>;
+  featured: Maybe<BooleanQueryOperatorInput>;
+  mainImage: Maybe<ContentfulAssetFilterInput>;
   description: Maybe<contentfulRecipeDescriptionTextNodeFilterInput>;
   ingredients: Maybe<contentfulRecipeIngredientsTextNodeFilterInput>;
   prepDirections: Maybe<contentfulRecipePrepDirectionsTextNodeFilterInput>;
@@ -24450,10 +24548,8 @@ type Query_contentfulRecipeArgs = {
   createdAt: Maybe<DateQueryOperatorInput>;
   updatedAt: Maybe<DateQueryOperatorInput>;
   sys: Maybe<ContentfulRecipeSysFilterInput>;
-  featured: Maybe<BooleanQueryOperatorInput>;
   ingredientTags: Maybe<ContentfulIngredientTagFilterListInput>;
   foodTypeTags: Maybe<ContentfulFoodTypeTagFilterListInput>;
-  mainImage: Maybe<ContentfulAssetFilterInput>;
   gatsbyPath: Maybe<StringQueryOperatorInput>;
   childrenContentfulRecipeNotesTextNode: Maybe<contentfulRecipeNotesTextNodeFilterListInput>;
   childContentfulRecipeNotesTextNode: Maybe<contentfulRecipeNotesTextNodeFilterInput>;
@@ -24855,6 +24951,7 @@ type Query_contentfulHomeBannerArgs = {
   titleLine2: Maybe<StringQueryOperatorInput>;
   ctaLink: Maybe<StringQueryOperatorInput>;
   ctaText: Maybe<StringQueryOperatorInput>;
+  image: Maybe<ContentfulAssetFilterInput>;
   body: Maybe<contentfulHomeBannerBodyTextNodeFilterInput>;
   spaceId: Maybe<StringQueryOperatorInput>;
   createdAt: Maybe<DateQueryOperatorInput>;
@@ -24882,6 +24979,7 @@ type Query_contentfulGetInvolvedCardArgs = {
   node_locale: Maybe<StringQueryOperatorInput>;
   title: Maybe<StringQueryOperatorInput>;
   link: Maybe<StringQueryOperatorInput>;
+  description: Maybe<StringQueryOperatorInput>;
   icon: Maybe<ContentfulAssetFilterInput>;
   spaceId: Maybe<StringQueryOperatorInput>;
   createdAt: Maybe<DateQueryOperatorInput>;
@@ -25100,101 +25198,21 @@ type Query_allContentfulHeaderSectionArgs = {
 };
 
 
-type Query_contentfulRecipeNotesTextNodeArgs = {
+type Query_contentfulHomeBannerBodyTextNodeArgs = {
   id: Maybe<StringQueryOperatorInput>;
   parent: Maybe<NodeFilterInput>;
   children: Maybe<NodeFilterListInput>;
   internal: Maybe<InternalFilterInput>;
-  notes: Maybe<StringQueryOperatorInput>;
-  sys: Maybe<contentfulRecipeNotesTextNodeSysFilterInput>;
+  body: Maybe<StringQueryOperatorInput>;
+  sys: Maybe<contentfulHomeBannerBodyTextNodeSysFilterInput>;
   childrenMarkdownRemark: Maybe<MarkdownRemarkFilterListInput>;
   childMarkdownRemark: Maybe<MarkdownRemarkFilterInput>;
 };
 
 
-type Query_allContentfulRecipeNotesTextNodeArgs = {
-  filter: Maybe<contentfulRecipeNotesTextNodeFilterInput>;
-  sort: Maybe<contentfulRecipeNotesTextNodeSortInput>;
-  skip: Maybe<Scalars['Int']>;
-  limit: Maybe<Scalars['Int']>;
-};
-
-
-type Query_contentfulRecipeDirectionsTextNodeArgs = {
-  id: Maybe<StringQueryOperatorInput>;
-  parent: Maybe<NodeFilterInput>;
-  children: Maybe<NodeFilterListInput>;
-  internal: Maybe<InternalFilterInput>;
-  directions: Maybe<StringQueryOperatorInput>;
-  sys: Maybe<contentfulRecipeDirectionsTextNodeSysFilterInput>;
-  childrenMarkdownRemark: Maybe<MarkdownRemarkFilterListInput>;
-  childMarkdownRemark: Maybe<MarkdownRemarkFilterInput>;
-};
-
-
-type Query_allContentfulRecipeDirectionsTextNodeArgs = {
-  filter: Maybe<contentfulRecipeDirectionsTextNodeFilterInput>;
-  sort: Maybe<contentfulRecipeDirectionsTextNodeSortInput>;
-  skip: Maybe<Scalars['Int']>;
-  limit: Maybe<Scalars['Int']>;
-};
-
-
-type Query_contentfulRecipePrepDirectionsTextNodeArgs = {
-  id: Maybe<StringQueryOperatorInput>;
-  parent: Maybe<NodeFilterInput>;
-  children: Maybe<NodeFilterListInput>;
-  internal: Maybe<InternalFilterInput>;
-  prepDirections: Maybe<StringQueryOperatorInput>;
-  sys: Maybe<contentfulRecipePrepDirectionsTextNodeSysFilterInput>;
-  childrenMarkdownRemark: Maybe<MarkdownRemarkFilterListInput>;
-  childMarkdownRemark: Maybe<MarkdownRemarkFilterInput>;
-};
-
-
-type Query_allContentfulRecipePrepDirectionsTextNodeArgs = {
-  filter: Maybe<contentfulRecipePrepDirectionsTextNodeFilterInput>;
-  sort: Maybe<contentfulRecipePrepDirectionsTextNodeSortInput>;
-  skip: Maybe<Scalars['Int']>;
-  limit: Maybe<Scalars['Int']>;
-};
-
-
-type Query_contentfulRecipeIngredientsTextNodeArgs = {
-  id: Maybe<StringQueryOperatorInput>;
-  parent: Maybe<NodeFilterInput>;
-  children: Maybe<NodeFilterListInput>;
-  internal: Maybe<InternalFilterInput>;
-  ingredients: Maybe<StringQueryOperatorInput>;
-  sys: Maybe<contentfulRecipeIngredientsTextNodeSysFilterInput>;
-  childrenMarkdownRemark: Maybe<MarkdownRemarkFilterListInput>;
-  childMarkdownRemark: Maybe<MarkdownRemarkFilterInput>;
-};
-
-
-type Query_allContentfulRecipeIngredientsTextNodeArgs = {
-  filter: Maybe<contentfulRecipeIngredientsTextNodeFilterInput>;
-  sort: Maybe<contentfulRecipeIngredientsTextNodeSortInput>;
-  skip: Maybe<Scalars['Int']>;
-  limit: Maybe<Scalars['Int']>;
-};
-
-
-type Query_contentfulRecipeDescriptionTextNodeArgs = {
-  id: Maybe<StringQueryOperatorInput>;
-  parent: Maybe<NodeFilterInput>;
-  children: Maybe<NodeFilterListInput>;
-  internal: Maybe<InternalFilterInput>;
-  description: Maybe<StringQueryOperatorInput>;
-  sys: Maybe<contentfulRecipeDescriptionTextNodeSysFilterInput>;
-  childrenMarkdownRemark: Maybe<MarkdownRemarkFilterListInput>;
-  childMarkdownRemark: Maybe<MarkdownRemarkFilterInput>;
-};
-
-
-type Query_allContentfulRecipeDescriptionTextNodeArgs = {
-  filter: Maybe<contentfulRecipeDescriptionTextNodeFilterInput>;
-  sort: Maybe<contentfulRecipeDescriptionTextNodeSortInput>;
+type Query_allContentfulHomeBannerBodyTextNodeArgs = {
+  filter: Maybe<contentfulHomeBannerBodyTextNodeFilterInput>;
+  sort: Maybe<contentfulHomeBannerBodyTextNodeSortInput>;
   skip: Maybe<Scalars['Int']>;
   limit: Maybe<Scalars['Int']>;
 };
@@ -25255,26 +25273,6 @@ type Query_contentfulDonationDetailSectionDescriptionTextNodeArgs = {
 type Query_allContentfulDonationDetailSectionDescriptionTextNodeArgs = {
   filter: Maybe<contentfulDonationDetailSectionDescriptionTextNodeFilterInput>;
   sort: Maybe<contentfulDonationDetailSectionDescriptionTextNodeSortInput>;
-  skip: Maybe<Scalars['Int']>;
-  limit: Maybe<Scalars['Int']>;
-};
-
-
-type Query_contentfulHomeBannerBodyTextNodeArgs = {
-  id: Maybe<StringQueryOperatorInput>;
-  parent: Maybe<NodeFilterInput>;
-  children: Maybe<NodeFilterListInput>;
-  internal: Maybe<InternalFilterInput>;
-  body: Maybe<StringQueryOperatorInput>;
-  sys: Maybe<contentfulHomeBannerBodyTextNodeSysFilterInput>;
-  childrenMarkdownRemark: Maybe<MarkdownRemarkFilterListInput>;
-  childMarkdownRemark: Maybe<MarkdownRemarkFilterInput>;
-};
-
-
-type Query_allContentfulHomeBannerBodyTextNodeArgs = {
-  filter: Maybe<contentfulHomeBannerBodyTextNodeFilterInput>;
-  sort: Maybe<contentfulHomeBannerBodyTextNodeSortInput>;
   skip: Maybe<Scalars['Int']>;
   limit: Maybe<Scalars['Int']>;
 };
@@ -25415,6 +25413,106 @@ type Query_contentfulAboutUsBannerDescriptionTextNodeArgs = {
 type Query_allContentfulAboutUsBannerDescriptionTextNodeArgs = {
   filter: Maybe<contentfulAboutUsBannerDescriptionTextNodeFilterInput>;
   sort: Maybe<contentfulAboutUsBannerDescriptionTextNodeSortInput>;
+  skip: Maybe<Scalars['Int']>;
+  limit: Maybe<Scalars['Int']>;
+};
+
+
+type Query_contentfulRecipeNotesTextNodeArgs = {
+  id: Maybe<StringQueryOperatorInput>;
+  parent: Maybe<NodeFilterInput>;
+  children: Maybe<NodeFilterListInput>;
+  internal: Maybe<InternalFilterInput>;
+  notes: Maybe<StringQueryOperatorInput>;
+  sys: Maybe<contentfulRecipeNotesTextNodeSysFilterInput>;
+  childrenMarkdownRemark: Maybe<MarkdownRemarkFilterListInput>;
+  childMarkdownRemark: Maybe<MarkdownRemarkFilterInput>;
+};
+
+
+type Query_allContentfulRecipeNotesTextNodeArgs = {
+  filter: Maybe<contentfulRecipeNotesTextNodeFilterInput>;
+  sort: Maybe<contentfulRecipeNotesTextNodeSortInput>;
+  skip: Maybe<Scalars['Int']>;
+  limit: Maybe<Scalars['Int']>;
+};
+
+
+type Query_contentfulRecipeDirectionsTextNodeArgs = {
+  id: Maybe<StringQueryOperatorInput>;
+  parent: Maybe<NodeFilterInput>;
+  children: Maybe<NodeFilterListInput>;
+  internal: Maybe<InternalFilterInput>;
+  directions: Maybe<StringQueryOperatorInput>;
+  sys: Maybe<contentfulRecipeDirectionsTextNodeSysFilterInput>;
+  childrenMarkdownRemark: Maybe<MarkdownRemarkFilterListInput>;
+  childMarkdownRemark: Maybe<MarkdownRemarkFilterInput>;
+};
+
+
+type Query_allContentfulRecipeDirectionsTextNodeArgs = {
+  filter: Maybe<contentfulRecipeDirectionsTextNodeFilterInput>;
+  sort: Maybe<contentfulRecipeDirectionsTextNodeSortInput>;
+  skip: Maybe<Scalars['Int']>;
+  limit: Maybe<Scalars['Int']>;
+};
+
+
+type Query_contentfulRecipePrepDirectionsTextNodeArgs = {
+  id: Maybe<StringQueryOperatorInput>;
+  parent: Maybe<NodeFilterInput>;
+  children: Maybe<NodeFilterListInput>;
+  internal: Maybe<InternalFilterInput>;
+  prepDirections: Maybe<StringQueryOperatorInput>;
+  sys: Maybe<contentfulRecipePrepDirectionsTextNodeSysFilterInput>;
+  childrenMarkdownRemark: Maybe<MarkdownRemarkFilterListInput>;
+  childMarkdownRemark: Maybe<MarkdownRemarkFilterInput>;
+};
+
+
+type Query_allContentfulRecipePrepDirectionsTextNodeArgs = {
+  filter: Maybe<contentfulRecipePrepDirectionsTextNodeFilterInput>;
+  sort: Maybe<contentfulRecipePrepDirectionsTextNodeSortInput>;
+  skip: Maybe<Scalars['Int']>;
+  limit: Maybe<Scalars['Int']>;
+};
+
+
+type Query_contentfulRecipeIngredientsTextNodeArgs = {
+  id: Maybe<StringQueryOperatorInput>;
+  parent: Maybe<NodeFilterInput>;
+  children: Maybe<NodeFilterListInput>;
+  internal: Maybe<InternalFilterInput>;
+  ingredients: Maybe<StringQueryOperatorInput>;
+  sys: Maybe<contentfulRecipeIngredientsTextNodeSysFilterInput>;
+  childrenMarkdownRemark: Maybe<MarkdownRemarkFilterListInput>;
+  childMarkdownRemark: Maybe<MarkdownRemarkFilterInput>;
+};
+
+
+type Query_allContentfulRecipeIngredientsTextNodeArgs = {
+  filter: Maybe<contentfulRecipeIngredientsTextNodeFilterInput>;
+  sort: Maybe<contentfulRecipeIngredientsTextNodeSortInput>;
+  skip: Maybe<Scalars['Int']>;
+  limit: Maybe<Scalars['Int']>;
+};
+
+
+type Query_contentfulRecipeDescriptionTextNodeArgs = {
+  id: Maybe<StringQueryOperatorInput>;
+  parent: Maybe<NodeFilterInput>;
+  children: Maybe<NodeFilterListInput>;
+  internal: Maybe<InternalFilterInput>;
+  description: Maybe<StringQueryOperatorInput>;
+  sys: Maybe<contentfulRecipeDescriptionTextNodeSysFilterInput>;
+  childrenMarkdownRemark: Maybe<MarkdownRemarkFilterListInput>;
+  childMarkdownRemark: Maybe<MarkdownRemarkFilterInput>;
+};
+
+
+type Query_allContentfulRecipeDescriptionTextNodeArgs = {
+  filter: Maybe<contentfulRecipeDescriptionTextNodeFilterInput>;
+  sort: Maybe<contentfulRecipeDescriptionTextNodeSortInput>;
   skip: Maybe<Scalars['Int']>;
   limit: Maybe<Scalars['Int']>;
 };
@@ -26547,6 +26645,11 @@ type WebPOptions = {
   readonly quality: Maybe<Scalars['Int']>;
 };
 
+type ArticlePreviewFragment = (
+  Pick<ContentfulBlogPost, 'title' | 'slug' | 'publishDate' | 'tags'>
+  & { readonly heroImage: Maybe<{ readonly fluid: Maybe<GatsbyContentfulFluidFragment> }>, readonly description: Maybe<{ readonly childMarkdownRemark: Maybe<Pick<MarkdownRemark, 'html'>> }> }
+);
+
 type BasicBannerFragment = (
   Pick<ContentfulHeaderSection, 'title'>
   & { readonly image: Maybe<(
@@ -26555,15 +26658,12 @@ type BasicBannerFragment = (
   )> }
 );
 
-type ArticlePreviewFragment = (
-  Pick<ContentfulBlogPost, 'title' | 'slug' | 'publishDate' | 'tags'>
-  & { readonly heroImage: Maybe<{ readonly fluid: Maybe<GatsbyContentfulFluidFragment> }>, readonly description: Maybe<{ readonly childMarkdownRemark: Maybe<Pick<MarkdownRemark, 'html'>> }> }
-);
+type HeaderFragment = { readonly headerImage: Maybe<(
+    Pick<ContentfulAsset, 'description'>
+    & { readonly fluid: Maybe<GatsbyContentfulFluidFragment> }
+  )> };
 
-type FooterQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type FooterQuery = { readonly contentfulAsset: Maybe<(
+type FooterFragment = { readonly footerImage: Maybe<(
     Pick<ContentfulAsset, 'description'>
     & { readonly fluid: Maybe<GatsbyContentfulFluidFragment> }
   )> };
@@ -26573,33 +26673,17 @@ type GetInvolvedCardFragment = (
   & { readonly icon: Maybe<{ readonly fluid: Maybe<GatsbyContentfulFluidFragment> }> }
 );
 
+type LayoutFragment = (
+  HeaderFragment
+  & FooterFragment
+);
+
 type OurWorkCardFragment = (
   Pick<ContentfulOurWorkCard, 'displayIndex' | 'title' | 'ctaLink' | 'ctaText'>
   & { readonly description: Maybe<{ readonly childMarkdownRemark: Maybe<Pick<MarkdownRemark, 'rawMarkdownBody'>> }>, readonly image: Maybe<(
     Pick<ContentfulAsset, 'description'>
     & { readonly fluid: Maybe<GatsbyContentfulFluidFragment> }
   )> }
-);
-
-type HeaderQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type HeaderQuery = { readonly contentfulAsset: Maybe<(
-    Pick<ContentfulAsset, 'description'>
-    & { readonly fluid: Maybe<GatsbyContentfulFluidFragment> }
-  )> };
-
-type VideoCardFragment = (
-  Pick<ContentfulVideoCard, 'title' | 'videoLink' | 'description'>
-  & { readonly thumbnail: Maybe<{ readonly fluid: Maybe<GatsbyContentfulFluidFragment> }> }
-);
-
-type RecipeCardFragment = (
-  Pick<ContentfulRecipe, 'id' | 'prepTime' | 'title' | 'totalTime' | 'updatedAt' | 'yield'>
-  & { readonly description: Maybe<Pick<contentfulRecipeDescriptionTextNode, 'description'>>, readonly ingredients: Maybe<Pick<contentfulRecipeIngredientsTextNode, 'ingredients'>>, readonly mainImage: Maybe<(
-    Pick<ContentfulAsset, 'description'>
-    & { readonly fluid: Maybe<GatsbyContentfulFluidFragment> }
-  )>, readonly foodTypeTags: Maybe<ReadonlyArray<Maybe<Pick<ContentfulFoodTypeTag, 'key' | 'tagName'>>>>, readonly ingredientTags: Maybe<ReadonlyArray<Maybe<Pick<ContentfulIngredientTag, 'key' | 'tagName'>>>> }
 );
 
 type PhotoCardFragment = (
@@ -26612,21 +26696,98 @@ type ResourceCardFragment = (
   & { readonly body: Maybe<{ readonly childMarkdownRemark: Maybe<Pick<MarkdownRemark, 'rawMarkdownBody'>> }> }
 );
 
-type ErrorPageQueryVariables = Exact<{ [key: string]: never; }>;
+type RecipeCardFragment = (
+  Pick<ContentfulRecipe, 'id' | 'prepTime' | 'title' | 'totalTime' | 'updatedAt' | 'yield'>
+  & { readonly description: Maybe<Pick<contentfulRecipeDescriptionTextNode, 'description'>>, readonly ingredients: Maybe<Pick<contentfulRecipeIngredientsTextNode, 'ingredients'>>, readonly mainImage: Maybe<(
+    Pick<ContentfulAsset, 'description'>
+    & { readonly fluid: Maybe<GatsbyContentfulFluidFragment> }
+  )>, readonly foodTypeTags: Maybe<ReadonlyArray<Maybe<Pick<ContentfulFoodTypeTag, 'key' | 'tagName'>>>>, readonly ingredientTags: Maybe<ReadonlyArray<Maybe<Pick<ContentfulIngredientTag, 'key' | 'tagName'>>>> }
+);
 
-
-type ErrorPageQuery = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'title'>> }>, readonly allContentfulErrorPage: { readonly nodes: ReadonlyArray<Pick<ContentfulErrorPage, 'node_locale' | 'heading' | 'subheading'>> } };
+type VideoCardFragment = (
+  Pick<ContentfulVideoCard, 'title' | 'videoLink' | 'description'>
+  & { readonly thumbnail: Maybe<{ readonly fluid: Maybe<GatsbyContentfulFluidFragment> }> }
+);
 
 type AboutPageQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 type AboutPageQuery = (
-  { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'title'>> }> }
+  LayoutFragment
   & AboutBannerFragment
   & OurWorkSectionFragment
   & OurStorySectionFragment
   & OurFounderSectionFragment
   & OurSponsorSectionFragment
+  & DonateBannerFragment
+  & NewsletterBannerFragment
+);
+
+type ErrorPageQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type ErrorPageQuery = (
+  { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'title'>> }>, readonly allContentfulErrorPage: { readonly nodes: ReadonlyArray<Pick<ContentfulErrorPage, 'node_locale' | 'heading' | 'subheading'>> } }
+  & LayoutFragment
+);
+
+type BlogPostBySlugQueryVariables = Exact<{
+  slug: Scalars['String'];
+}>;
+
+
+type BlogPostBySlugQuery = (
+  { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'title'>> }>, readonly contentfulBlogPost: Maybe<(
+    Pick<ContentfulBlogPost, 'title' | 'publishDate'>
+    & { readonly heroImage: Maybe<{ readonly fluid: Maybe<GatsbyContentfulFluidFragment> }>, readonly body: Maybe<{ readonly childMarkdownRemark: Maybe<Pick<MarkdownRemark, 'html'>> }> }
+  )> }
+  & LayoutFragment
+);
+
+type DemoPageQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type DemoPageQuery = LayoutFragment;
+
+type BlogIndexQueryQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type BlogIndexQueryQuery = (
+  { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'title'>> }>, readonly allContentfulBlogPost: { readonly nodes: ReadonlyArray<ArticlePreviewFragment> } }
+  & LayoutFragment
+);
+
+type DonationPageQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type DonationPageQuery = (
+  { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'title'>> }> }
+  & LayoutFragment
+);
+
+type GetInvolvedPageQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type GetInvolvedPageQuery = (
+  { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'title'>> }>, readonly allContentfulHeaderSection: { readonly nodes: ReadonlyArray<(
+      Pick<ContentfulHeaderSection, 'node_locale'>
+      & BasicBannerFragment
+    )> } }
+  & LayoutFragment
+  & DonationDetailFragment
+  & DonateBannerFragment
+  & GetInvolvedSectionFragment
+  & NewsletterBannerFragment
+);
+
+type HomePageQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type HomePageQuery = (
+  LayoutFragment
+  & HomeBannerFragment
+  & FeaturedRecipesSectionFragment
+  & OurWorkSectionFragment
   & DonateBannerFragment
   & NewsletterBannerFragment
 );
@@ -26639,48 +26800,16 @@ type EventsPageQuery = (
       Pick<ContentfulHeaderSection, 'node_locale'>
       & BasicBannerFragment
     )> } }
+  & LayoutFragment
   & DonateBannerFragment
   & NewsletterBannerFragment
 );
 
-type BlogIndexQueryQueryVariables = Exact<{ [key: string]: never; }>;
+type RecipePageQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type BlogIndexQueryQuery = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'title'>> }>, readonly allContentfulBlogPost: { readonly nodes: ReadonlyArray<ArticlePreviewFragment> } };
-
-type BlogPostBySlugQueryVariables = Exact<{
-  slug: Scalars['String'];
-}>;
-
-
-type BlogPostBySlugQuery = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'title'>> }>, readonly contentfulBlogPost: Maybe<(
-    Pick<ContentfulBlogPost, 'title' | 'publishDate'>
-    & { readonly heroImage: Maybe<{ readonly fluid: Maybe<GatsbyContentfulFluidFragment> }>, readonly body: Maybe<{ readonly childMarkdownRemark: Maybe<Pick<MarkdownRemark, 'html'>> }> }
-  )> };
-
-type DonationQueryQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type DonationQueryQuery = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'title'>> }> };
-
-type GetInvolvedPageQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type GetInvolvedPageQuery = (
-  { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'title'>> }>, readonly allContentfulHeaderSection: { readonly nodes: ReadonlyArray<(
-      Pick<ContentfulHeaderSection, 'node_locale'>
-      & BasicBannerFragment
-    )> } }
-  & DonationDetailFragment
-  & DonateBannerFragment
-  & GetInvolvedSectionFragment
-  & NewsletterBannerFragment
-);
-
-type RecipeQueryQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type RecipeQueryQuery = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'title'>> }>, readonly allContentfulRecipe: { readonly nodes: ReadonlyArray<(
+type RecipePageQuery = (
+  { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'title'>> }>, readonly allContentfulRecipe: { readonly nodes: ReadonlyArray<(
       Pick<ContentfulRecipe, 'node_locale'>
       & { readonly directions: Maybe<Pick<contentfulRecipeDirectionsTextNode, 'directions'>> }
       & RecipeCardFragment
@@ -26690,18 +26819,8 @@ type RecipeQueryQuery = { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pi
     )> }, readonly allContentfulFoodTypeTag: { readonly nodes: ReadonlyArray<(
       Pick<ContentfulFoodTypeTag, 'tagName' | 'key' | 'node_locale'>
       & { readonly recipe: Maybe<ReadonlyArray<Maybe<Pick<ContentfulRecipe, 'id'>>>> }
-    )> }, readonly contentfulTimeList: Maybe<Pick<ContentfulTimeList, 'timeList'>> };
-
-type HomePageQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type HomePageQuery = (
-  { readonly site: Maybe<{ readonly siteMetadata: Maybe<Pick<SiteSiteMetadata, 'title'>> }> }
-  & HomeBannerFragment
-  & FeaturedRecipesSectionFragment
-  & OurWorkSectionFragment
-  & DonateBannerFragment
-  & NewsletterBannerFragment
+    )> }, readonly contentfulTimeList: Maybe<Pick<ContentfulTimeList, 'timeList'>> }
+  & LayoutFragment
 );
 
 type RecipeByTitleQueryVariables = Exact<{
@@ -26709,10 +26828,24 @@ type RecipeByTitleQueryVariables = Exact<{
 }>;
 
 
-type RecipeByTitleQuery = { readonly contentfulRecipe: Maybe<(
+type RecipeByTitleQuery = (
+  { readonly contentfulRecipe: Maybe<(
     Pick<ContentfulRecipe, 'title' | 'totalTime' | 'prepTime' | 'yield'>
     & { readonly mainImage: Maybe<{ readonly fluid: Maybe<GatsbyContentfulFluidFragment> }>, readonly ingredients: Maybe<Pick<contentfulRecipeIngredientsTextNode, 'ingredients'>>, readonly directions: Maybe<Pick<contentfulRecipeDirectionsTextNode, 'directions'>>, readonly prepDirections: Maybe<Pick<contentfulRecipePrepDirectionsTextNode, 'prepDirections'>>, readonly notes: Maybe<Pick<contentfulRecipeNotesTextNode, 'notes'>> }
-  )> };
+  )> }
+  & LayoutFragment
+);
+
+type AboutBannerFragment = { readonly allContentfulAboutBanner: { readonly nodes: ReadonlyArray<(
+      Pick<ContentfulAboutBanner, 'title' | 'node_locale'>
+      & { readonly body: Maybe<{ readonly childMarkdownRemark: Maybe<Pick<MarkdownRemark, 'rawMarkdownBody'>> }>, readonly logo: Maybe<(
+        Pick<ContentfulAsset, 'description'>
+        & { readonly fluid: Maybe<GatsbyContentfulFluidFragment> }
+      )>, readonly image: Maybe<(
+        Pick<ContentfulAsset, 'description'>
+        & { readonly fluid: Maybe<GatsbyContentfulFluidFragment> }
+      )> }
+    )> } };
 
 type ResourcesPageQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -26722,6 +26855,7 @@ type ResourcesPageQuery = (
       Pick<ContentfulHeaderSection, 'node_locale'>
       & BasicBannerFragment
     )> } }
+  & LayoutFragment
   & LinkDocFragment
   & MediaGalleryFragment
   & DonateBannerFragment
@@ -26739,6 +26873,14 @@ type DonateBannerFragment = { readonly allContentfulDonateSection: { readonly no
       )> }
     )> } };
 
+type DonationDetailFragment = { readonly allContentfulDonationDetailSection: { readonly nodes: ReadonlyArray<(
+      Pick<ContentfulDonationDetailSection, 'title' | 'node_locale'>
+      & { readonly description: Maybe<{ readonly childMarkdownRemark: Maybe<Pick<MarkdownRemark, 'rawMarkdownBody'>> }>, readonly image: Maybe<(
+        Pick<ContentfulAsset, 'description'>
+        & { readonly fluid: Maybe<GatsbyContentfulFluidFragment> }
+      )> }
+    )> } };
+
 type FeaturedRecipesSectionFragment = { readonly allContentfulRecipe: { readonly nodes: ReadonlyArray<(
       Pick<ContentfulRecipe, 'node_locale'>
       & RecipeCardFragment
@@ -26746,28 +26888,17 @@ type FeaturedRecipesSectionFragment = { readonly allContentfulRecipe: { readonly
 
 type GetInvolvedSectionFragment = { readonly allContentfulGetInvolvedCard: { readonly nodes: ReadonlyArray<GetInvolvedCardFragment> } };
 
-type HomeBannerFragment = { readonly allContentfulHomeBanner: { readonly nodes: ReadonlyArray<(
-      Pick<ContentfulHomeBanner, 'titleLine1' | 'titleLine2' | 'ctaLink' | 'ctaText' | 'node_locale'>
-      & { readonly body: Maybe<{ readonly childMarkdownRemark: Maybe<Pick<MarkdownRemark, 'rawMarkdownBody'>> }> }
-    )> } };
-
-type AboutBannerFragment = { readonly allContentfulAboutBanner: { readonly nodes: ReadonlyArray<(
-      Pick<ContentfulAboutBanner, 'title' | 'node_locale'>
-      & { readonly body: Maybe<{ readonly childMarkdownRemark: Maybe<Pick<MarkdownRemark, 'rawMarkdownBody'>> }>, readonly logo: Maybe<(
-        Pick<ContentfulAsset, 'description'>
-        & { readonly fluid: Maybe<GatsbyContentfulFluidFragment> }
-      )>, readonly image: Maybe<(
-        Pick<ContentfulAsset, 'description'>
-        & { readonly fluid: Maybe<GatsbyContentfulFluidFragment> }
-      )> }
-    )> } };
-
 type LinkDocFragment = { readonly allContentfulLinkDocSection: { readonly nodes: ReadonlyArray<(
       Pick<ContentfulLinkDocSection, 'title' | 'node_locale'>
       & { readonly body: Maybe<{ readonly childMarkdownRemark: Maybe<Pick<MarkdownRemark, 'rawMarkdownBody'>> }> }
     )> }, readonly allContentfulResourceCard: { readonly nodes: ReadonlyArray<(
       Pick<ContentfulResourceCard, 'node_locale'>
       & ResourceCardFragment
+    )> } };
+
+type HomeBannerFragment = { readonly allContentfulHomeBanner: { readonly nodes: ReadonlyArray<(
+      Pick<ContentfulHomeBanner, 'titleLine1' | 'titleLine2' | 'ctaLink' | 'ctaText' | 'node_locale'>
+      & { readonly body: Maybe<{ readonly childMarkdownRemark: Maybe<Pick<MarkdownRemark, 'rawMarkdownBody'>> }> }
     )> } };
 
 type MediaGalleryFragment = { readonly allContentfulPhotoCard: { readonly nodes: ReadonlyArray<(
@@ -26778,19 +26909,22 @@ type MediaGalleryFragment = { readonly allContentfulPhotoCard: { readonly nodes:
       & VideoCardFragment
     )> } };
 
-type DonationDetailFragment = { readonly allContentfulDonationDetailSection: { readonly nodes: ReadonlyArray<(
-      Pick<ContentfulDonationDetailSection, 'title' | 'node_locale'>
+type NewsletterBannerFragment = { readonly allContentfulNewsletterSection: { readonly nodes: ReadonlyArray<Pick<ContentfulNewsletterSection, 'headline' | 'ctaLink' | 'ctaText' | 'node_locale'>> } };
+
+type OurFounderSectionFragment = { readonly allContentfulOurFounder: { readonly nodes: ReadonlyArray<(
+      Pick<ContentfulOurFounder, 'title' | 'ctaLink' | 'ctaText' | 'node_locale'>
       & { readonly description: Maybe<{ readonly childMarkdownRemark: Maybe<Pick<MarkdownRemark, 'rawMarkdownBody'>> }>, readonly image: Maybe<(
         Pick<ContentfulAsset, 'description'>
         & { readonly fluid: Maybe<GatsbyContentfulFluidFragment> }
       )> }
     )> } };
 
-type NewsletterBannerFragment = { readonly allContentfulNewsletterSection: { readonly nodes: ReadonlyArray<Pick<ContentfulNewsletterSection, 'headline' | 'ctaLink' | 'ctaText' | 'node_locale'>> } };
-
-type OurWorkSectionFragment = { readonly allContentfulOurWorkCard: { readonly nodes: ReadonlyArray<(
-      Pick<ContentfulOurWorkCard, 'node_locale'>
-      & OurWorkCardFragment
+type OurStorySectionFragment = { readonly allContentfulOurStory: { readonly nodes: ReadonlyArray<(
+      Pick<ContentfulOurStory, 'title' | 'node_locale'>
+      & { readonly body: Maybe<{ readonly childMarkdownRemark: Maybe<Pick<MarkdownRemark, 'rawMarkdownBody'>> }>, readonly image: Maybe<(
+        Pick<ContentfulAsset, 'description'>
+        & { readonly fluid: Maybe<GatsbyContentfulFluidFragment> }
+      )> }
     )> } };
 
 type OurSponsorSectionFragment = { readonly allContentfulOurSponsor: { readonly nodes: ReadonlyArray<(
@@ -26804,20 +26938,9 @@ type OurSponsorSectionFragment = { readonly allContentfulOurSponsor: { readonly 
       )>>> }
     )> } };
 
-type OurStorySectionFragment = { readonly allContentfulOurStory: { readonly nodes: ReadonlyArray<(
-      Pick<ContentfulOurStory, 'title' | 'node_locale'>
-      & { readonly body: Maybe<{ readonly childMarkdownRemark: Maybe<Pick<MarkdownRemark, 'rawMarkdownBody'>> }>, readonly image: Maybe<(
-        Pick<ContentfulAsset, 'description'>
-        & { readonly fluid: Maybe<GatsbyContentfulFluidFragment> }
-      )> }
-    )> } };
-
-type OurFounderSectionFragment = { readonly allContentfulOurFounder: { readonly nodes: ReadonlyArray<(
-      Pick<ContentfulOurFounder, 'title' | 'ctaLink' | 'ctaText' | 'node_locale'>
-      & { readonly description: Maybe<{ readonly childMarkdownRemark: Maybe<Pick<MarkdownRemark, 'rawMarkdownBody'>> }>, readonly image: Maybe<(
-        Pick<ContentfulAsset, 'description'>
-        & { readonly fluid: Maybe<GatsbyContentfulFluidFragment> }
-      )> }
+type OurWorkSectionFragment = { readonly allContentfulOurWorkCard: { readonly nodes: ReadonlyArray<(
+      Pick<ContentfulOurWorkCard, 'node_locale'>
+      & OurWorkCardFragment
     )> } };
 
 type GatsbyContentfulFixedFragment = Pick<ContentfulFixed, 'base64' | 'width' | 'height' | 'src' | 'srcSet'>;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -11,25 +11,18 @@ import {
   HStack,
   Select,
 } from '@chakra-ui/react';
-import { Link as GatsbyLink, graphql, useStaticQuery } from 'gatsby';
+import { Link as GatsbyLink, graphql } from 'gatsby';
 import Img from 'gatsby-image';
 import { useLocale } from 'src/contexts/LocaleContext';
 import { Locale } from 'src/utils/types';
 
 import { FacebookIcon, InstagramIcon, EmailIcon } from './Icons';
 
-function Footer(): JSX.Element {
-  const data: GatsbyTypes.FooterQuery = useStaticQuery<GatsbyTypes.FooterQuery>(graphql`
-    query Footer {
-      contentfulAsset(title: { eq: "Logo Transparent" }) {
-        fluid(quality: 100) {
-          ...GatsbyContentfulFluid
-        }
-        description
-      }
-    }
-  `);
+interface Props {
+  data: GatsbyTypes.FooterFragment;
+}
 
+function Footer({ data }: Props): JSX.Element {
   const [show1, setShow1] = useState(false);
   const [show2, setShow2] = useState(false);
   const [show3, setShow3] = useState(false);
@@ -43,10 +36,10 @@ function Footer(): JSX.Element {
   const { locale, setLocale } = useLocale();
 
   const logo =
-    data.contentfulAsset?.fluid != null ? (
+    data.footerImage?.fluid != null ? (
       <Img
-        fluid={data.contentfulAsset.fluid}
-        alt={data.contentfulAsset.description}
+        fluid={data.footerImage.fluid}
+        alt={data.footerImage.description}
         imgStyle={{ objectFit: 'contain' }}
         style={{ maxHeight: `158px` }}
       />
@@ -269,3 +262,14 @@ function Footer(): JSX.Element {
 }
 
 export default Footer;
+
+export const fragment = graphql`
+  fragment Footer on Query {
+    footerImage: contentfulAsset(title: { eq: "Logo Transparent" }) {
+      fluid(quality: 100) {
+        ...GatsbyContentfulFluid
+      }
+      description
+    }
+  }
+`;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,34 +1,22 @@
-import React, { useContext } from 'react';
+import React from 'react';
 
 import { HamburgerIcon } from '@chakra-ui/icons';
 import { Box, Button, Spacer, Flex } from '@chakra-ui/react';
-import { graphql, useStaticQuery } from 'gatsby';
+import { graphql } from 'gatsby';
 import Img from 'gatsby-image';
 import { NavLink } from 'src/components/Navigation';
 
-interface HeaderProps {
+interface Props {
+  data: GatsbyTypes.HeaderFragment;
   onHamburgerClick: () => void;
 }
 
-function Header({ onHamburgerClick }: HeaderProps): JSX.Element {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const data: GatsbyTypes.HeaderQuery = useStaticQuery<GatsbyTypes.HeaderQuery>(graphql`
-    query Header {
-      contentfulAsset(title: { eq: "Logo" }) {
-        fluid(quality: 100) {
-          ...GatsbyContentfulFluid
-        }
-        description
-      }
-    }
-  `);
-
+function Header({ data, onHamburgerClick }: Props): JSX.Element {
   const hfhfLogo =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    data.contentfulAsset?.fluid != null ? (
+    data.headerImage?.fluid != null ? (
       <Img
-        fluid={data.contentfulAsset.fluid}
-        alt={data.contentfulAsset.description}
+        fluid={data.headerImage.fluid}
+        alt={data.headerImage.description}
         imgStyle={{ objectFit: 'contain' }}
       />
     ) : null;
@@ -85,3 +73,14 @@ function Header({ onHamburgerClick }: HeaderProps): JSX.Element {
 }
 
 export default Header;
+
+export const fragment = graphql`
+  fragment Header on Query {
+    headerImage: contentfulAsset(title: { eq: "Logo" }) {
+      fluid(quality: 100) {
+        ...GatsbyContentfulFluid
+      }
+      description
+    }
+  }
+`;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,28 +3,36 @@ import 'focus-visible/dist/focus-visible';
 import React from 'react';
 
 import { Container, useDisclosure } from '@chakra-ui/react';
+import { graphql } from 'gatsby';
 
 import Footer from './Footer';
 import Header from './Header';
 import Navigation from './Navigation';
 
 interface Props {
-  location: Location;
+  data: GatsbyTypes.LayoutFragment;
   children: React.ReactChild | React.ReactChild[];
 }
 
-function Layout({ children }: Props): JSX.Element {
+function Layout({ data, children }: Props): JSX.Element {
   // Hook to manage side-navigation drawer
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
     <Container size="full" maxW="none" p={0}>
-      <Header onHamburgerClick={onOpen} />
+      <Header data={data} onHamburgerClick={onOpen} />
       <Navigation isDrawerOpen={isOpen} onDrawerClose={onClose} />
       {children}
-      <Footer />
+      <Footer data={data} />
     </Container>
   );
 }
 
 export default Layout;
+
+export const fragment = graphql`
+  fragment Layout on Query {
+    ...Header
+    ...Footer
+  }
+`;

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -10,14 +10,14 @@ interface Props extends PageProps {
   data: GatsbyTypes.ErrorPageQuery;
 }
 
-const ErrorPage = ({ data, location }: Props) => {
+const ErrorPage = ({ data }: Props) => {
   const { findLocale } = useLocale();
   const theme = useTheme();
 
   const page = findLocale(data.allContentfulErrorPage.nodes);
 
   return (
-    <Layout location={location}>
+    <Layout data={data}>
       <Flex h="790px" alignItems="center" justifyContent="space-evenly">
         <Box w="709px">
           <Heading fontSize="50px" lineHeight="78px" fontWeight={850}>
@@ -54,6 +54,7 @@ export default ErrorPage;
 
 export const fragment = graphql`
   query ErrorPage {
+    ...Layout
     site {
       siteMetadata {
         title

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -14,21 +14,21 @@ interface Props extends PageProps {
   data: GatsbyTypes.AboutPageQuery;
 }
 
-function AboutPage(props: Props): JSX.Element {
+function AboutPage({ data }: Props): JSX.Element {
   return (
-    <Layout location={props.location}>
-      <AboutBanner data={props.data} />
+    <Layout data={data}>
+      <AboutBanner data={data} />
 
-      <OurStorySection data={props.data} />
+      <OurStorySection data={data} />
 
-      <OurWorkSection data={props.data} />
+      <OurWorkSection data={data} />
 
-      <OurFounderSection data={props.data} />
+      <OurFounderSection data={data} />
 
-      <OurSponsorSection data={props.data} />
+      <OurSponsorSection data={data} />
 
-      <DonateSection data={props.data} />
-      <NewsletterBanner data={props.data} />
+      <DonateSection data={data} />
+      <NewsletterBanner data={data} />
     </Layout>
   );
 }
@@ -37,11 +37,7 @@ export default AboutPage;
 
 export const pageQuery = graphql`
   query AboutPage {
-    site {
-      siteMetadata {
-        title
-      }
-    }
+    ...Layout
     ...AboutBanner
     ...OurWorkSection
     ...OurStorySection

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -16,7 +16,7 @@ function BlogIndex(props: Props): JSX.Element {
   const posts = props.data?.allContentfulBlogPost?.nodes;
 
   return (
-    <Layout location={props.location}>
+    <Layout data={props.data}>
       <div style={{ background: '#fff' }}>
         <Helmet title={siteTitle} />
         <div className={styles.hero}>Blog</div>
@@ -47,6 +47,7 @@ export const pageQuery = graphql`
         title
       }
     }
+    ...Layout
     allContentfulBlogPost(sort: { fields: [publishDate], order: DESC }) {
       nodes {
         ...ArticlePreview

--- a/src/pages/blog/{ContentfulBlogPost.slug}.tsx
+++ b/src/pages/blog/{ContentfulBlogPost.slug}.tsx
@@ -21,7 +21,7 @@ function BlogPostTemplate(props: Props): JSX.Element {
   }
 
   return (
-    <Layout location={props.location}>
+    <Layout data={props.data}>
       <div style={{ background: '#fff' }}>
         <Helmet title={`${post?.title ?? ''} | ${siteTitle ?? ''}`} />
         <div className={heroStyles.hero}>
@@ -56,6 +56,7 @@ export const pageQuery = graphql`
         title
       }
     }
+    ...Layout
     contentfulBlogPost(slug: { eq: $slug }) {
       title
       publishDate(formatString: "MMMM Do, YYYY")

--- a/src/pages/demo.tsx
+++ b/src/pages/demo.tsx
@@ -16,12 +16,10 @@ import {
   Wrap,
   WrapItem,
 } from '@chakra-ui/react';
-import { PageProps } from 'gatsby';
+import { graphql, PageProps } from 'gatsby';
 import { MdChevronLeft, MdSearch } from 'react-icons/md';
 
 import Layout from '../components/Layout';
-
-type Props = PageProps;
 
 function ColorTile({
   hex,
@@ -50,9 +48,13 @@ function ColorTile({
   );
 }
 
+interface Props extends PageProps {
+  data: GatsbyTypes.DemoPageQuery;
+}
+
 function DemoPage(props: Props): JSX.Element {
   return (
-    <Layout location={props.location}>
+    <Layout data={props.data}>
       <Heading textStyle="heading1" mb={5}>
         Colors
       </Heading>
@@ -133,3 +135,9 @@ function DemoPage(props: Props): JSX.Element {
 }
 
 export default DemoPage;
+
+export const query = graphql`
+  query DemoPage {
+    ...Layout
+  }
+`;

--- a/src/pages/donations.tsx
+++ b/src/pages/donations.tsx
@@ -2,19 +2,16 @@ import React from 'react';
 
 import { Container, Heading } from '@chakra-ui/react';
 import { graphql, PageProps } from 'gatsby';
-import { Helmet } from 'react-helmet';
 import Layout from 'src/components/Layout';
 
 interface Props extends PageProps {
-  data: GatsbyTypes.DonationQueryQuery;
+  data: GatsbyTypes.DonationPageQuery;
 }
 
 function DonationIndex(props: Props): JSX.Element {
-  const siteTitle = props.data.site?.siteMetadata?.title || '';
   return (
-    <Layout location={props.location}>
+    <Layout data={props.data}>
       <Container alignItems="center">
-        <Helmet title={`Donations | ${siteTitle}`} />
         <Heading as="h1" size="3xl">
           Donations
         </Heading>
@@ -26,11 +23,12 @@ function DonationIndex(props: Props): JSX.Element {
 export default DonationIndex;
 
 export const pageQuery = graphql`
-  query DonationQuery {
+  query DonationPage {
     site {
       siteMetadata {
         title
       }
     }
+    ...Layout
   }
 `;

--- a/src/pages/events-classes.tsx
+++ b/src/pages/events-classes.tsx
@@ -19,7 +19,7 @@ function EventsPage(props: Props): JSX.Element {
   const header = findLocale(props.data.allContentfulHeaderSection.nodes);
 
   return (
-    <Layout location={props.location}>
+    <Layout data={props.data}>
       <BasicBanner data={header} />
       <EventCalendarSection />
       <UpcomingEventsSection />
@@ -44,6 +44,7 @@ export const pageQuery = graphql`
         node_locale
       }
     }
+    ...Layout
     ...DonateBanner
     ...NewsletterBanner
   }

--- a/src/pages/get-involved.tsx
+++ b/src/pages/get-involved.tsx
@@ -13,14 +13,13 @@ interface Props extends PageProps {
   data: GatsbyTypes.GetInvolvedPageQuery;
 }
 
-const GetInvolvedPage = (props: Props) => {
-  const { data, location } = props;
+const GetInvolvedPage = ({ data }: Props) => {
   const { findLocale } = useLocale();
 
   const header = findLocale(data.allContentfulHeaderSection.nodes);
 
   return (
-    <Layout location={location}>
+    <Layout data={data}>
       <BasicBanner data={header} />
       <GetInvolvedSection data={data} />
       <DonationDetailSection data={data} />
@@ -45,6 +44,7 @@ export const pageQuery = graphql`
         node_locale
       }
     }
+    ...Layout
     ...DonationDetail
     ...DonateBanner
     ...GetInvolvedSection

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,7 +14,7 @@ interface Props extends PageProps {
 
 function RootIndex(props: Props): JSX.Element {
   return (
-    <Layout location={props.location}>
+    <Layout data={props.data}>
       <HomeBanner data={props.data} />
 
       <OurWorkSection data={props.data} />
@@ -30,11 +30,7 @@ export default RootIndex;
 
 export const pageQuery = graphql`
   query HomePage {
-    site {
-      siteMetadata {
-        title
-      }
-    }
+    ...Layout
     ...HomeBanner
     ...FeaturedRecipesSection
     ...OurWorkSection

--- a/src/pages/recipes.tsx
+++ b/src/pages/recipes.tsx
@@ -17,7 +17,7 @@ import { entries, keys, removeNulls } from 'src/utils/util';
 import { NoSearchIcon } from '../components/Icons';
 
 interface Props extends PageProps {
-  data: GatsbyTypes.RecipeQueryQuery;
+  data: GatsbyTypes.RecipePageQuery;
 }
 
 function RecipesIndex(props: Props): JSX.Element {
@@ -89,7 +89,7 @@ function RecipesIndex(props: Props): JSX.Element {
   const pageCount = Math.ceil(filteredRecipes.length / recipesPerPage);
 
   return (
-    <Layout location={props.location}>
+    <Layout data={props.data}>
       <Helmet title={siteTitle} />
 
       <Grid templateColumns={{ base: '1fr', md: '250px 1px 1fr' }} mb={10}>
@@ -151,12 +151,13 @@ function RecipesIndex(props: Props): JSX.Element {
 export default RecipesIndex;
 
 export const pageQuery = graphql`
-  query RecipeQuery {
+  query RecipePage {
     site {
       siteMetadata {
         title
       }
     }
+    ...Layout
     allContentfulRecipe {
       nodes {
         ...RecipeCard

--- a/src/pages/recipes/{ContentfulRecipe.title}.tsx
+++ b/src/pages/recipes/{ContentfulRecipe.title}.tsx
@@ -1,7 +1,17 @@
 import React from 'react';
 
 import { ChevronLeftIcon } from '@chakra-ui/icons';
-import { Flex, Heading, Text, HStack, VStack, Box, Button, Grid } from '@chakra-ui/react';
+import {
+  Flex,
+  Heading,
+  Text,
+  HStack,
+  VStack,
+  Box,
+  Button,
+  Grid,
+  useBreakpointValue,
+} from '@chakra-ui/react';
 import { graphql, Link, PageProps } from 'gatsby';
 import Img from 'gatsby-image';
 
@@ -17,8 +27,10 @@ function RecipeTemplate(props: Props): JSX.Element {
   const contentfulRecipe = props.data.contentfulRecipe;
   const recipe = parseRecipe(contentfulRecipe as GatsbyTypes.ContentfulRecipe);
 
+  const titleTextStyle = useBreakpointValue({ base: 'subheading1', md: 'heading1' });
+
   return (
-    <Layout location={props.location}>
+    <Layout data={props.data}>
       <Box w={{ base: '89%', md: 'none' }} margin={{ base: 5, md: 10 }}>
         <Link to="/recipes">
           <Button
@@ -31,7 +43,7 @@ function RecipeTemplate(props: Props): JSX.Element {
           </Button>
         </Link>
         <Heading
-          textStyle={{ base: 'subheading1', md: 'heading1' }}
+          textStyle={titleTextStyle}
           textAlign={{ base: 'center', md: 'start' }}
           marginBottom={5}
         >
@@ -153,6 +165,7 @@ export default RecipeTemplate;
 
 export const pageQuery = graphql`
   query RecipeByTitle($title: String!) {
+    ...Layout
     contentfulRecipe(title: { eq: $title }) {
       title
       mainImage {

--- a/src/pages/resources.tsx
+++ b/src/pages/resources.tsx
@@ -13,13 +13,13 @@ interface Props extends PageProps {
   data: GatsbyTypes.ResourcesPageQuery;
 }
 
-function ResourcesPage({ data, location }: Props): JSX.Element {
+function ResourcesPage({ data }: Props): JSX.Element {
   const { findLocale } = useLocale();
 
   const header = findLocale(data.allContentfulHeaderSection.nodes);
 
   return (
-    <Layout location={location}>
+    <Layout data={data}>
       <BasicBanner data={header} />
       <LinkDocSection data={data} />
       <MediaGallerySection data={data} />
@@ -44,6 +44,7 @@ export const pageQuery = graphql`
         node_locale
       }
     }
+    ...Layout
     ...LinkDoc
     ...MediaGallery
     ...DonateBanner

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -1,7 +1,7 @@
 import { Category, RecipeFilters, SelectedRecipeFilters, Tag } from './types';
 import { removeNulls } from './util';
 
-type RecipeQuery = GatsbyTypes.RecipeQueryQuery;
+type RecipeQuery = GatsbyTypes.RecipePageQuery;
 
 // Initializes tags in sidebar based on all Contentful tags of each category
 export function initRecipeFilters(


### PR DESCRIPTION
Our typegen plugin has had some consistent issues with `useStaticQuery` in `Header.tsx` and `Footer.tsx`. This change converts each of their queries to fragments. This means each page has to pass data down to `Layout`, and include `...Layout` in its query. This should also make it easier to Contentful-ify these components in the future.

This change also:
- fixes a small type error in the individual recipe page
- strips out titles from each page, but we'll add them back in later